### PR TITLE
feat: package snippet

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -5,6 +5,7 @@
     "nativewind",
     "SUPABASE",
     "tailwind",
-    "tailwindcss"
+    "tailwindcss",
+    "typecheck"
   ]
 }

--- a/apps/country-tracker/package.json
+++ b/apps/country-tracker/package.json
@@ -43,14 +43,14 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@biomejs/biome": "*",
+    "@biomejs/biome": "catalog:",
     "@types/jest": "^29.5.13",
     "@types/react": "~18.2.79",
     "@types/react-test-renderer": "^18.3.0",
     "jest": "^29.7.0",
     "jest-expo": "~51.0.4",
     "react-test-renderer": "18.2.0",
-    "type-fest": "*",
-    "typescript": "~5.3.3"
+    "type-fest": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "turbo run test"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.9.3",
+    "@biomejs/biome": "catalog:",
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^19.5.0",
     "@commitlint/types": "^19.5.0",
@@ -24,7 +24,8 @@
     "sort-package-json": "^2.10.1",
     "tsx": "^4.19.1",
     "turbo": "^2.1.3",
-    "type-fest": "^4.26.1",
+    "type-fest": "catalog:",
+    "typescript": "catalog:",
     "yaml": "^2.5.1"
   },
   "packageManager": "pnpm@9.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,12 +4,24 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@biomejs/biome':
+      specifier: ^1.9.3
+      version: 1.9.3
+    type-fest:
+      specifier: ^4.26.1
+      version: 4.26.1
+    typescript:
+      specifier: ~5.3.3
+      version: 5.3.3
+
 importers:
 
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: ^1.9.3
+        specifier: 'catalog:'
         version: 1.9.3
       '@commitlint/cli':
         specifier: ^19.5.0
@@ -51,8 +63,11 @@ importers:
         specifier: ^2.1.3
         version: 2.1.3
       type-fest:
-        specifier: ^4.26.1
+        specifier: 'catalog:'
         version: 4.26.1
+      typescript:
+        specifier: 'catalog:'
+        version: 5.3.3
       yaml:
         specifier: ^2.5.1
         version: 2.5.1
@@ -136,7 +151,7 @@ importers:
         specifier: ^7.20.0
         version: 7.25.2
       '@biomejs/biome':
-        specifier: '*'
+        specifier: 'catalog:'
         version: 1.9.3
       '@types/jest':
         specifier: ^29.5.13
@@ -157,10 +172,10 @@ importers:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
       type-fest:
-        specifier: '*'
+        specifier: 'catalog:'
         version: 4.26.1
       typescript:
-        specifier: ~5.3.3
+        specifier: 'catalog:'
         version: 5.3.3
 
 packages:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
 packages:
   - apps/*
   - packages/*
+
+catalog:
+  "@biomejs/biome": ^1.9.3
+  typescript: ~5.3.3
+  type-fest: ^4.26.1

--- a/turbo/generators/templates/native/package.json
+++ b/turbo/generators/templates/native/package.json
@@ -43,14 +43,14 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@biomejs/biome": "*",
+    "@biomejs/biome": "catalog:",
     "@types/jest": "^29.5.13",
     "@types/react": "~18.2.79",
     "@types/react-test-renderer": "^18.3.0",
     "jest": "^29.7.0",
     "jest-expo": "~51.0.4",
     "react-test-renderer": "18.2.0",
-    "type-fest": "*",
-    "typescript": "~5.3.3"
+    "type-fest": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/turbo/generators/templates/package/package.json
+++ b/turbo/generators/templates/package/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "package",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "git clean -xdf .cache .turbo dist node_modules",
+    "dev": "tsc",
+    "lint": "biome lint --write --no-errors-on-unmatched",
+    "type-check": "tsc --noEmit --emitDeclarationOnly false"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "catalog:",
+    "type-fest": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/turbo/generators/templates/package/src/index.ts
+++ b/turbo/generators/templates/package/src/index.ts
@@ -1,0 +1,3 @@
+export function add(a: number, b: number) {
+  return a + b;
+}

--- a/turbo/generators/templates/package/tsconfig.json.hbs
+++ b/turbo/generators/templates/package/tsconfig.json.hbs
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    /** Base Options */
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "moduleDetection": "force",
+    "isolatedModules": true,
+
+    /** Keep TSC performant in monorepos */
+    "incremental": true,
+    "disableSourceOfProjectReferenceRedirect": true,
+    "tsBuildInfoFile": "${configDir}/.cache/tsbuildinfo.json",
+
+    /** Strictness */
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "checkJs": true,
+
+    /** Transpile using Bundler (not tsc) */
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    // "noEmit": true,
+
+    /** Emit types for internal packages to speed up editor performance. */
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "outDir": "${configDir}/dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "build", "dist", ".next", ".expo"]
+}


### PR DESCRIPTION
## 설명 (Description)

- package 를 turbo gen으로 생성할 수 있게 추가합니다.

## 관련 이슈 (Related Issues)

- 이 PR과 관련된 이슈 번호를 적어주세요. (예: `#123`)

## 스크린샷/동영상 (Screenshots/Videos)

- 생성 커맨드
<img width="829" alt="Screenshot 2024-10-12 at 21 41 00" src="https://github.com/user-attachments/assets/79e64140-9136-4b13-9f4e-6286f3409e27">

- 패키지 생성 완료
<img width="358" alt="Screenshot 2024-10-12 at 21 41 13" src="https://github.com/user-attachments/assets/edfd98fb-2ce4-4210-9c2a-bc5ba4aca6ab">

## 변경 내용 (Changes Made)

- turbo/generators/config.ts
 - gitignore 가 있는 경우만 생성 (handlebar에서 dotfile을 읽지못해서 처리해줬는데, 있는 경우만 확인하게 조건 추가했어요)
 - 패키지명은 내부 설치해야해서 `@infinite-loop-factory/` Prefix 를 붙혀줬는데, 앱도 붙히는게 나을것 같으면 말씀 부탁드립니다. 
- turbo/generators/templates/package
  - 스니펫 폴더이고, tsconfig 는 이후에 공통으로 쓸 것들 뽑으면 될 것 같습니다.

## 테스트 방법 (How to Test)

- `pnpm turbo gen`

## 추가 정보 (Additional Context)

- [create-t3-turbo/tooling/typescript](https://github.com/t3-oss/create-t3-turbo/blob/main/tooling/typescript/internal-package.json)