### PR TITLE
fix: 🐛 cla comment 추가시 액션 실행

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,5 +1,7 @@
 name: "CLA Assistant"
 on:
+  issue_comment:
+    types: [created]
   pull_request_target:
     types: [opened, closed, synchronize]
 


### PR DESCRIPTION
## 설명 (Description)

- 삭제했던 코멘트 이벤트 살렸습니다.
- 이슈 코멘트 달았던 시점에 돌길래 삭제했으나  PR에서 서명할 때 한번 트리거 되게 하기 위해 의도한 동작이였습니다.

## 관련 이슈 (Related Issues)

- #21  https://github.com/infinite-loop-factory/app-factory/pull/21/files#diff-7aa0bb52169dde77e9033b3f574e1c8e686f567ea884691c7aace8f6297d216eL3
