### PR TITLE
fix(country-tracker): 🐛 nested scroll views error

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1,5 +1,6 @@
 {
   "words": [
+    "actionsheet",
     "autodocs",
     "biomejs",
     "devmoji",

--- a/apps/country-tracker/components/ParallaxScrollView.tsx
+++ b/apps/country-tracker/components/ParallaxScrollView.tsx
@@ -1,21 +1,41 @@
-import type { PropsWithChildren } from "react";
-
-import { ThemedView } from "@/components/ThemedView";
 import { useThemeColor } from "@/hooks/useThemeColor";
+import type { PropsWithChildren } from "react";
 import Animated, { useAnimatedRef } from "react-native-reanimated";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { ThemedView } from "./ThemedView";
 
-export default function ParallaxScrollView({ children }: PropsWithChildren) {
+interface ParallaxScrollViewProps extends PropsWithChildren {
+  scrollEnabled?: boolean;
+}
+
+export default function ParallaxScrollView({
+  children,
+  scrollEnabled = true,
+}: ParallaxScrollViewProps) {
   const scrollRef = useAnimatedRef<Animated.ScrollView>();
   const backgroundColor = useThemeColor({}, "background");
 
+  if (scrollEnabled) {
+    return (
+      <SafeAreaView className="flex-1" style={[{ backgroundColor }]}>
+        <Animated.ScrollView
+          ref={scrollRef}
+          scrollEventThrottle={16}
+          contentContainerStyle={{ flexGrow: 1 }}
+        >
+          <ThemedView className="flex-1 gap-4 overflow-hidden p-8">
+            {children}
+          </ThemedView>
+        </Animated.ScrollView>
+      </SafeAreaView>
+    );
+  }
+
   return (
     <SafeAreaView className="flex-1" style={[{ backgroundColor }]}>
-      <Animated.ScrollView ref={scrollRef} scrollEventThrottle={16}>
-        <ThemedView className="flex-1 gap-4 overflow-hidden p-8">
-          {children}
-        </ThemedView>
-      </Animated.ScrollView>
+      <ThemedView className="flex-1 gap-4 overflow-hidden p-8">
+        {children}
+      </ThemedView>
     </SafeAreaView>
   );
 }

--- a/apps/country-tracker/components/ui/divider/index.tsx
+++ b/apps/country-tracker/components/ui/divider/index.tsx
@@ -1,0 +1,40 @@
+"use client";
+import type { VariantProps } from "@gluestack-ui/nativewind-utils";
+import { tva } from "@gluestack-ui/nativewind-utils/tva";
+import React from "react";
+import { Platform, View } from "react-native";
+
+const dividerStyle = tva({
+  base: "bg-background-200",
+  variants: {
+    orientation: {
+      vertical: "w-px h-full",
+      horizontal: "h-px w-full",
+    },
+  },
+});
+
+type IUIDividerProps = React.ComponentPropsWithoutRef<typeof View> &
+  VariantProps<typeof dividerStyle>;
+
+const Divider = React.forwardRef<
+  React.ElementRef<typeof View>,
+  IUIDividerProps
+>(({ className, orientation = "horizontal", ...props }, ref) => {
+  return (
+    <View
+      ref={ref}
+      {...props}
+      aria-orientation={orientation}
+      role={Platform.OS === "web" ? "separator" : undefined}
+      className={dividerStyle({
+        orientation,
+        class: className,
+      })}
+    />
+  );
+});
+
+Divider.displayName = "Divider";
+
+export { Divider };

--- a/apps/country-tracker/features/home/components/home-screen.tsx
+++ b/apps/country-tracker/features/home/components/home-screen.tsx
@@ -1,5 +1,6 @@
 import ParallaxScrollView from "@/components/ParallaxScrollView";
 import { Box } from "@/components/ui/box";
+import { Divider } from "@/components/ui/divider";
 import { Heading } from "@/components/ui/heading";
 import { Input, InputField, InputIcon, InputSlot } from "@/components/ui/input";
 import { Text } from "@/components/ui/text";
@@ -22,17 +23,20 @@ const data: CountryItem[] = [
 
 export default function HomeScreen() {
   const renderItem: ListRenderItem<CountryItem> = ({ item }) => (
-    <Box className="mt-4 flex flex-row justify-between border-gray-100 border-b p-2">
-      <Box className="flex flex-1 flex-row gap-2">
-        <Text>{item.flag}</Text>
-        <Text>{item.country}</Text>
+    <VStack>
+      <Box className="mt-4 flex flex-row justify-between p-2">
+        <Box className="flex flex-1 flex-row gap-2">
+          <Text>{item.flag}</Text>
+          <Text>{item.country}</Text>
+        </Box>
+        <Text className="font-mono text-gray-500">{item.lastVisitDate}</Text>
       </Box>
-      <Text className="font-mono text-gray-500">{item.lastVisitDate}</Text>
-    </Box>
+      <Divider className="my-0.5" />
+    </VStack>
   );
 
   return (
-    <ParallaxScrollView>
+    <ParallaxScrollView scrollEnabled={false}>
       <FlatList
         data={data}
         keyExtractor={(item) => item.id}

--- a/apps/country-tracker/package.json
+++ b/apps/country-tracker/package.json
@@ -19,6 +19,7 @@
     "@expo/html-elements": "^0.4.2",
     "@expo/vector-icons": "^14.0.4",
     "@gluestack-ui/actionsheet": "^0.2.46",
+    "@gluestack-ui/divider": "^0.1.10",
     "@gluestack-ui/input": "^0.1.32",
     "@gluestack-ui/nativewind-utils": "^1.0.26",
     "@gluestack-ui/overlay": "^0.1.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       '@gluestack-ui/actionsheet':
         specifier: ^0.2.46
         version: 0.2.46(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
+      '@gluestack-ui/divider':
+        specifier: ^0.1.10
+        version: 0.1.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@gluestack-ui/input':
         specifier: ^0.1.32
         version: 0.1.32(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)
@@ -2110,6 +2113,12 @@ packages:
 
   '@gluestack-ui/button@1.0.7':
     resolution: {integrity: sha512-6hz5BPoB+iHMpDvys6AbIpeRPbnFiqyE3SnnbKPSCj8lgl3Dr9sFln41BvDmqmZ98d0usJluk50rz8pVNRZRgw==}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
+
+  '@gluestack-ui/divider@0.1.10':
+    resolution: {integrity: sha512-/hZx1Rmy4Pgln9AwAprAEQcxYPEHjHSNF4xCUWlK/q0peyiMT5Nagt54VnxykVn5A0b2zg5QKP0pOqOF9xeE6w==}
     peerDependencies:
       react: '>=16'
       react-dom: '>=16'
@@ -10427,6 +10436,11 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - react-native
+
+  '@gluestack-ui/divider@0.1.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
 
   '@gluestack-ui/form-control@0.1.18(react-dom@18.2.0(react@18.2.0))(react-native@0.74.5(@babel/core@7.25.2)(@babel/preset-env@7.25.4(@babel/core@7.25.2))(@types/react@18.2.79)(react@18.2.0))(react@18.2.0)':
     dependencies:


### PR DESCRIPTION
## 설명 (Description)

<img width="440" alt="Screenshot 2024-12-22 at 17 33 52" src="https://github.com/user-attachments/assets/145047dc-3dff-4a4a-83d3-94cc9c199257" />

- 중첩 스크롤 뷰로 인해 버그나는거 잡았습니다.

## 관련 이슈 (Related Issues)

- #23 

## 스크린샷/동영상 (Screenshots/Videos)

<img width="927" alt="Screenshot 2024-12-22 at 17 46 47" src="https://github.com/user-attachments/assets/3af4d958-b028-4f68-a28d-c89d52a8f69e" />

## 변경 내용 (Changes Made)

- scrollEnabled 속성을 추가해서 FlatList 쓸 때 우회해줬습니다.
- gluestack divider를 추가해서 border-b 대신 사용했습니다.

## 테스트 방법 (How to Test)

- pnpm start

## 체크리스트 (Checklist)

- [x] iOS에서 테스트 완료
- [ ] Android에서 테스트 완료
- [x] 웹에서 테스트 완료