### PR TITLE
feat(country-tracker): 지구본 테마, 이동 추가

### DIFF
--- a/apps/country-tracker/src/features/map/components/map-globe.native.tsx
+++ b/apps/country-tracker/src/features/map/components/map-globe.native.tsx
@@ -1,14 +1,39 @@
 import * as Location from "expo-location";
-import { useEffect, useState } from "react";
-import MapView from "react-native-maps";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+import MapView, { type Region } from "react-native-maps";
 
-export default function MapGlobe() {
-  const [region, setRegion] = useState({
+export interface MapGlobeRef {
+  moveToLocation: (latitude: number, longitude: number) => void;
+}
+
+const MapGlobe = forwardRef<MapGlobeRef>((_, ref) => {
+  const mapRef = useRef<MapView>(null);
+  const [region, setRegion] = useState<Region>({
     latitude: 37.7749,
     longitude: -122.4194,
     latitudeDelta: 75,
     longitudeDelta: 75,
   });
+
+  useImperativeHandle(ref, () => ({
+    moveToLocation: (latitude: number, longitude: number) => {
+      const newRegion = {
+        latitude,
+        longitude,
+        latitudeDelta: 25,
+        longitudeDelta: 25,
+      };
+
+      setRegion(newRegion);
+      mapRef.current?.animateToRegion(newRegion, 1500);
+    },
+  }));
 
   useEffect(() => {
     (async () => {
@@ -25,10 +50,13 @@ export default function MapGlobe() {
 
   return (
     <MapView
+      ref={mapRef}
       style={{ flex: 1 }}
       showsCompass={false}
       mapType="satelliteFlyover"
       region={region}
     />
   );
-}
+});
+
+export default MapGlobe;

--- a/apps/country-tracker/src/features/map/components/map-globe.native.tsx
+++ b/apps/country-tracker/src/features/map/components/map-globe.native.tsx
@@ -1,3 +1,5 @@
+import type { Region } from "react-native-maps";
+
 import * as Location from "expo-location";
 import {
   forwardRef,
@@ -6,7 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
-import MapView, { type Region } from "react-native-maps";
+import MapView from "react-native-maps";
 
 export interface MapGlobeRef {
   moveToLocation: (latitude: number, longitude: number) => void;

--- a/apps/country-tracker/src/features/map/components/map-screen.tsx
+++ b/apps/country-tracker/src/features/map/components/map-screen.tsx
@@ -3,6 +3,7 @@ import { Button, ButtonIcon } from "@/components/ui/button";
 import { Heading } from "@/components/ui/heading";
 import { Input, InputField, InputIcon, InputSlot } from "@/components/ui/input";
 import MapGlobe from "@/features/map/components/map-globe";
+import { useThemeColor } from "@/hooks/useThemeColor";
 import BottomSheet, { BottomSheetView } from "@gorhom/bottom-sheet";
 import { Search, Share } from "lucide-react-native";
 import { useRef, useState } from "react";
@@ -11,6 +12,8 @@ import { View } from "react-native";
 export default function MapScreen() {
   const bottomSheetRef = useRef<BottomSheet>(null);
   const [searchText, setSearchText] = useState("");
+  const [backgroundColor, inputBackgroundColor, borderColor, textColor] =
+    useThemeColor(["background", "background-50", "outline-200", "typography"]);
 
   const handleSheetChanges = (index: number) => {
     // biome-ignore lint/suspicious/noConsole: 테스트
@@ -35,16 +38,27 @@ export default function MapScreen() {
         onChange={handleSheetChanges}
         snapPoints={["40%", "90%", "14%"]}
         enableDynamicSizing={false}
+        backgroundStyle={{ backgroundColor }}
+        handleIndicatorStyle={{ backgroundColor: textColor }}
       >
         <BottomSheetView className="px-4 py-2">
           <View className="mb-2 flex flex-row items-center justify-between">
-            <Heading className="font-bold text-xl">Countries</Heading>
+            <Heading
+              className="font-bold text-2xl"
+              style={{ color: textColor }}
+            >
+              Countries
+            </Heading>
             <Button onPress={handleShare} variant="link" className="mr-1">
               <ButtonIcon as={Share} />
             </Button>
           </View>
 
-          <Input className="rounded-full border px-4 py-3 shadow-xs">
+          <Input
+            className="rounded-full border px-4 py-3 shadow-xs"
+            size="lg"
+            style={{ backgroundColor: inputBackgroundColor, borderColor }}
+          >
             <InputField
               placeholder="Search for a country..."
               value={searchText}

--- a/apps/country-tracker/src/features/map/constants/countries.ts
+++ b/apps/country-tracker/src/features/map/constants/countries.ts
@@ -1,0 +1,39 @@
+export interface CountryLocation {
+  country: string;
+  latitude: number;
+  longitude: number;
+}
+
+// * 국가 위치
+export const COUNTRY_LOCATIONS: CountryLocation[] = [
+  { country: "France", latitude: 46.603354, longitude: 1.888334 },
+  { country: "Japan", latitude: 36.204824, longitude: 138.252924 },
+  { country: "United States", latitude: 37.09024, longitude: -95.712891 },
+  { country: "South Korea", latitude: 35.907757, longitude: 127.766922 },
+  { country: "Germany", latitude: 51.165691, longitude: 10.451526 },
+  { country: "Thailand", latitude: 15.870032, longitude: 100.992541 },
+  { country: "Brazil", latitude: -14.235004, longitude: -51.92528 },
+  { country: "United Kingdom", latitude: 55.378051, longitude: -3.435973 },
+  { country: "China", latitude: 35.86166, longitude: 104.195397 },
+  { country: "Canada", latitude: 56.130366, longitude: -106.346771 },
+  { country: "Australia", latitude: -25.274398, longitude: 133.775136 },
+  { country: "Russia", latitude: 61.52401, longitude: 105.318756 },
+  { country: "Italy", latitude: 41.87194, longitude: 12.56738 },
+  { country: "Spain", latitude: 40.463667, longitude: -3.74922 },
+  { country: "Mexico", latitude: 23.634501, longitude: -102.552784 },
+  { country: "Netherlands", latitude: 52.132633, longitude: 5.291266 },
+  { country: "South Africa", latitude: -30.559482, longitude: 22.937506 },
+  { country: "Argentina", latitude: -38.416097, longitude: -63.616672 },
+  { country: "New Zealand", latitude: -40.900557, longitude: 174.885971 },
+];
+
+/**
+ * 국가 이름으로 위치 정보 찾기
+ */
+export function findCountryLocation(
+  countryName: string,
+): CountryLocation | undefined {
+  return COUNTRY_LOCATIONS.find(
+    (location) => location.country.toLowerCase() === countryName.toLowerCase(),
+  );
+}


### PR DESCRIPTION
## 설명 (Description)

- 지구본 바텀시트 테마 추가하고, 국가명 입력시 지도 이동하게 추가했습니다.

## 관련 이슈 (Related Issues)

-  #98

## 스크린샷/동영상 (Screenshots/Videos)

<img width="410" alt="Screenshot 2025-04-20 at 20 09 30" src="https://github.com/user-attachments/assets/76570399-e545-4bfc-874e-1af59f17889e" />


## 변경 내용 (Changes Made)

-  mapGlobe forwardRef추가해서 제어 가능하게 했습니다.

## 테스트 방법 (How to Test)

- pnpm start country-tracker

## 체크리스트 (Checklist)

- [x] iOS에서 테스트 완료
- [ ] Android에서 테스트 완료
- [ ] 웹에서 테스트 완료
- [ ] 관련 문서 업데이트 완료 (필요시)
