### PR TITLE
feat(dog-walk): Tmap 도보 경로 훅, Toast UI 추가 및 IconText/TabKey 타입 리팩토링

### DIFF
--- a/apps/dog-walk/app/(screens)/detail/[id].tsx
+++ b/apps/dog-walk/app/(screens)/detail/[id].tsx
@@ -9,9 +9,9 @@ import { Button, ButtonText } from "@/components/ui/button";
 import { HStack } from "@/components/ui/hstack";
 import { Text } from "@/components/ui/text";
 import { VStack } from "@/components/ui/vstack";
-import { IconTextEnum, TabKeyEnum } from "@/types/displayType";
+import { IconTextType, TabKeyType } from "@/types/displayType";
 import { useLocalSearchParams } from "expo-router";
-import { useMemo, useState } from "react";
+import { memo, useMemo, useRef, useState } from "react";
 import { Dimensions, FlatList, Image, ScrollView, View } from "react-native";
 
 export default function DetailScreen() {
@@ -19,7 +19,7 @@ export default function DetailScreen() {
 
   const { id } = useLocalSearchParams();
 
-  const [selectedTab, setSelectedTab] = useState(TabKeyEnum.INFO);
+  const [selectedTab, setSelectedTab] = useState<TabKeyType>(TabKeyType.INFO);
 
   const [isFavorite, setIsFavorite] = useState(false);
 
@@ -36,49 +36,45 @@ export default function DetailScreen() {
       "몽마르뜨 공원은 강아지와 함께 산책하기에 최적의 장소입니다. 다음과 같은 이유로 반려견 산책 코스로 추천합니다.",
   });
 
-  const tabInfo = useMemo(() => {
+  const tabInfo: { key: TabKeyType; title: string }[] = useMemo(() => {
     return [
-      { key: TabKeyEnum.INFO, title: "정보" },
-      { key: TabKeyEnum.MAP, title: "지도" },
-      { key: TabKeyEnum.REVIEW, title: "리뷰" },
+      { key: TabKeyType.INFO, title: "정보" },
+      { key: TabKeyType.MAP, title: "지도" },
+      { key: TabKeyType.REVIEW, title: "리뷰" },
     ];
   }, []);
 
-  const startPlace = useMemo(() => {
-    return {
-      longitude: 127.0022,
-      latitude: 37.49328,
-    };
-  }, []);
+  const startPlace = useRef({
+    longitude: 127.0022,
+    latitude: 37.49328,
+  }).current;
 
-  const endPlace = useMemo(() => {
-    return {
-      latitude: 37.49649,
-      longitude: 127.004,
-    };
-  }, []);
+  const endPlace = useRef({
+    latitude: 37.49649,
+    longitude: 127.004,
+  }).current;
 
-  const courseInfoItems: { type: IconTextEnum; content: string }[] = [
-    { type: IconTextEnum.CLOCK, content: `${course.totalTime}분` },
-    { type: IconTextEnum.MAP, content: `${course.distance}km` },
+  const courseInfoItems: { type: IconTextType; content: string }[] = [
+    { type: IconTextType.CLOCK, content: `${course.totalTime}분` },
+    { type: IconTextType.MAP, content: `${course.distance}km` },
     {
-      type: IconTextEnum.STAR,
+      type: IconTextType.STAR,
       content: `${course.rate} (${course.reviewCount})`,
     },
   ];
 
-  const TabContent = ({ selectedTab }: { selectedTab: TabKeyEnum }) => {
+  const TabContent = memo(({ selectedTab }: { selectedTab: TabKeyType }) => {
     switch (selectedTab) {
-      case TabKeyEnum.INFO:
+      case TabKeyType.INFO:
         return <DetailDescription content={course.description} />;
-      case TabKeyEnum.MAP:
+      case TabKeyType.MAP:
         return <DetailMap start={startPlace} end={endPlace} />;
-      case TabKeyEnum.REVIEW:
+      case TabKeyType.REVIEW:
         return <Reviews />;
       default:
         return null;
     }
-  };
+  });
 
   return (
     <CustomSafeAreaView>
@@ -96,7 +92,7 @@ export default function DetailScreen() {
               {course.title}
             </Text>
 
-            <IconText type={IconTextEnum.MAP} content={course.address} />
+            <IconText type={IconTextType.MAP} content={course.address} />
 
             <HStack className="items-center gap-4">
               {courseInfoItems.map((data) => (

--- a/apps/dog-walk/components/CustomToast.tsx
+++ b/apps/dog-walk/components/CustomToast.tsx
@@ -1,0 +1,60 @@
+import type React from "react";
+import { useState } from "react";
+import { Platform } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { HStack } from "./ui/hstack";
+import { HelpCircleIcon, Icon } from "./ui/icon";
+import { Text } from "./ui/text";
+import { Toast, useToast } from "./ui/toast";
+
+let globalHandleToast: ((message: string) => void) | null = null;
+
+export const CustomToast: React.FC = () => {
+  const toast = useToast();
+  const [toastId, setToastId] = useState<string | null>(null);
+
+  const handleToast = (message: string) => {
+    if (toastId === null || !toast.isActive(String(toastId))) {
+      showNewToast(message);
+    }
+  };
+
+  const ToastContent = ({ id, message }: { id: string; message: string }) => (
+    <Toast nativeID={`toast-${id}`} action="muted" variant="solid">
+      <HStack space="md" className="items-center">
+        <Icon as={HelpCircleIcon} className="h-4 w-4 text-background-0" />
+        <Text className="text-typography-0">{message}</Text>
+      </HStack>
+    </Toast>
+  );
+
+  const showNewToast = (message: string) => {
+    const newId = Math.random().toString();
+    setToastId(newId);
+
+    toast.show({
+      id: newId,
+      placement: "top",
+      duration: 3000,
+      render: ({ id }) => {
+        const content = <ToastContent id={id} message={message} />;
+        return Platform.OS === "android" ? (
+          <SafeAreaView>{content}</SafeAreaView>
+        ) : (
+          content
+        );
+      },
+    });
+  };
+
+  globalHandleToast = handleToast;
+
+  return null;
+};
+
+export const getGlobalHandleToast = (message: string) => {
+  if (!globalHandleToast) {
+    throw new Error("ToastManager is not initialized");
+  }
+  return globalHandleToast(message);
+};

--- a/apps/dog-walk/components/atoms/IconText.tsx
+++ b/apps/dog-walk/components/atoms/IconText.tsx
@@ -1,4 +1,4 @@
-import { IconTextEnum } from "@/types/displayType";
+import { IconTextType } from "@/types/displayType";
 import { Clock, MapPin, Star } from "lucide-react-native";
 import { useCallback } from "react";
 import { HStack } from "../ui/hstack";
@@ -6,17 +6,17 @@ import { Icon } from "../ui/icon";
 import { Text } from "../ui/text";
 
 interface IIconTextProps {
-  type: IconTextEnum;
+  type: IconTextType;
   content: string;
 }
 
 export default function IconText({ type, content }: IIconTextProps) {
   const renderIcon = useCallback(() => {
-    if (type === IconTextEnum.MAP) {
+    if (type === IconTextType.MAP) {
       return MapPin;
     }
 
-    if (type === IconTextEnum.CLOCK) {
+    if (type === IconTextType.CLOCK) {
       return Clock;
     }
     return Star;

--- a/apps/dog-walk/components/ui/toast/index.tsx
+++ b/apps/dog-walk/components/ui/toast/index.tsx
@@ -1,0 +1,240 @@
+"use client";
+import type { VariantProps } from "@gluestack-ui/nativewind-utils";
+import { tva } from "@gluestack-ui/nativewind-utils/tva";
+import {
+  useStyleContext,
+  withStyleContext,
+} from "@gluestack-ui/nativewind-utils/withStyleContext";
+import { createToastHook } from "@gluestack-ui/toast";
+import {
+  AnimatePresence,
+  Motion,
+  type MotionComponentProps,
+} from "@legendapp/motion";
+import { cssInterop } from "nativewind";
+import React from "react";
+import { AccessibilityInfo, Text, View, type ViewStyle } from "react-native";
+
+type IMotionViewProps = React.ComponentProps<typeof View> &
+  MotionComponentProps<typeof View, ViewStyle, unknown, unknown, unknown>;
+
+const MotionView = Motion.View as React.ComponentType<IMotionViewProps>;
+
+const useToast = createToastHook(MotionView, AnimatePresence);
+const SCOPE = "TOAST";
+
+cssInterop(MotionView, { className: "style" });
+
+const toastStyle = tva({
+  base: "p-4 m-1 rounded-md gap-1 web:pointer-events-auto shadow-hard-5 border-outline-100",
+  variants: {
+    action: {
+      error: "bg-error-800",
+      warning: "bg-warning-700",
+      success: "bg-success-700",
+      info: "bg-info-700",
+      muted: "bg-background-800",
+    },
+
+    variant: {
+      solid: "",
+      outline: "border bg-background-0",
+    },
+  },
+});
+
+const toastTitleStyle = tva({
+  base: "text-typography-0 font-medium font-body tracking-md text-left",
+  variants: {
+    isTruncated: {
+      true: "",
+    },
+    bold: {
+      true: "font-bold",
+    },
+    underline: {
+      true: "underline",
+    },
+    strikeThrough: {
+      true: "line-through",
+    },
+    size: {
+      "2xs": "text-2xs",
+      xs: "text-xs",
+      sm: "text-sm",
+      md: "text-base",
+      lg: "text-lg",
+      xl: "text-xl",
+      "2xl": "text-2xl",
+      "3xl": "text-3xl",
+      "4xl": "text-4xl",
+      "5xl": "text-5xl",
+      "6xl": "text-6xl",
+    },
+  },
+  parentVariants: {
+    variant: {
+      solid: "",
+      outline: "",
+    },
+    action: {
+      error: "",
+      warning: "",
+      success: "",
+      info: "",
+      muted: "",
+    },
+  },
+  parentCompoundVariants: [
+    {
+      variant: "outline",
+      action: "error",
+      class: "text-error-800",
+    },
+    {
+      variant: "outline",
+      action: "warning",
+      class: "text-warning-800",
+    },
+    {
+      variant: "outline",
+      action: "success",
+      class: "text-success-800",
+    },
+    {
+      variant: "outline",
+      action: "info",
+      class: "text-info-800",
+    },
+    {
+      variant: "outline",
+      action: "muted",
+      class: "text-background-800",
+    },
+  ],
+});
+
+const toastDescriptionStyle = tva({
+  base: "font-normal font-body tracking-md text-left",
+  variants: {
+    isTruncated: {
+      true: "",
+    },
+    bold: {
+      true: "font-bold",
+    },
+    underline: {
+      true: "underline",
+    },
+    strikeThrough: {
+      true: "line-through",
+    },
+    size: {
+      "2xs": "text-2xs",
+      xs: "text-xs",
+      sm: "text-sm",
+      md: "text-base",
+      lg: "text-lg",
+      xl: "text-xl",
+      "2xl": "text-2xl",
+      "3xl": "text-3xl",
+      "4xl": "text-4xl",
+      "5xl": "text-5xl",
+      "6xl": "text-6xl",
+    },
+  },
+  parentVariants: {
+    variant: {
+      solid: "text-typography-50",
+      outline: "text-typography-900",
+    },
+  },
+});
+
+const Root = withStyleContext(View, SCOPE);
+type IToastProps = React.ComponentProps<typeof Root> & {
+  className?: string;
+} & VariantProps<typeof toastStyle>;
+
+const Toast = React.forwardRef<React.ComponentRef<typeof Root>, IToastProps>(
+  function Toast(
+    { className, variant = "solid", action = "muted", ...props },
+    ref,
+  ) {
+    return (
+      <Root
+        ref={ref}
+        className={toastStyle({ variant, action, class: className })}
+        context={{ variant, action }}
+        {...props}
+      />
+    );
+  },
+);
+
+type IToastTitleProps = React.ComponentProps<typeof Text> & {
+  className?: string;
+} & VariantProps<typeof toastTitleStyle>;
+
+const ToastTitle = React.forwardRef<
+  React.ComponentRef<typeof Text>,
+  IToastTitleProps
+>(function ToastTitle({ className, size = "md", children, ...props }, ref) {
+  const { variant: parentVariant, action: parentAction } =
+    useStyleContext(SCOPE);
+  React.useEffect(() => {
+    // Issue from react-native side
+    // Hack for now, will fix this later
+    AccessibilityInfo.announceForAccessibility(children as string);
+  }, [children]);
+
+  return (
+    <Text
+      {...props}
+      ref={ref}
+      aria-live="assertive"
+      aria-atomic="true"
+      role="alert"
+      className={toastTitleStyle({
+        size,
+        class: className,
+        parentVariants: {
+          variant: parentVariant,
+          action: parentAction,
+        },
+      })}
+    >
+      {children}
+    </Text>
+  );
+});
+
+type IToastDescriptionProps = React.ComponentProps<typeof Text> & {
+  className?: string;
+} & VariantProps<typeof toastDescriptionStyle>;
+
+const ToastDescription = React.forwardRef<
+  React.ComponentRef<typeof Text>,
+  IToastDescriptionProps
+>(function ToastDescription({ className, size = "md", ...props }, ref) {
+  const { variant: parentVariant } = useStyleContext(SCOPE);
+  return (
+    <Text
+      ref={ref}
+      {...props}
+      className={toastDescriptionStyle({
+        size,
+        class: className,
+        parentVariants: {
+          variant: parentVariant,
+        },
+      })}
+    />
+  );
+});
+
+Toast.displayName = "Toast";
+ToastTitle.displayName = "ToastTitle";
+ToastDescription.displayName = "ToastDescription";
+
+export { useToast, Toast, ToastTitle, ToastDescription };

--- a/apps/dog-walk/hooks/usePedestrianRoutes.ts
+++ b/apps/dog-walk/hooks/usePedestrianRoutes.ts
@@ -1,0 +1,83 @@
+import { useState } from "react";
+
+interface IDetailMapProps {
+  start: {
+    latitude: number;
+    longitude: number;
+  };
+  end: {
+    latitude: number;
+    longitude: number;
+  };
+}
+
+interface Coord {
+  lat: number;
+  lon: number;
+}
+
+interface TMapResponse {
+  features: {
+    geometry: {
+      type: string;
+      coordinates: [number, number][];
+    };
+  }[];
+}
+
+export default function usePedestrianRoutes() {
+  const [pathCoords, setPathCoords] = useState<Coord[]>([]);
+
+  const fetchRoutes = async ({ start, end }: IDetailMapProps) => {
+    if (!(start.latitude && start.longitude && end.latitude && end.longitude))
+      return;
+
+    const requestBody = {
+      startX: start.longitude,
+      startY: start.latitude,
+      endX: end.longitude,
+      endY: end.latitude,
+      reqCoordType: "WGS84GEO",
+      resCoordType: "WGS84GEO",
+      startName: "출발지",
+      endName: "도착지",
+    };
+
+    try {
+      const res = await fetch(
+        "https://apis.openapi.sk.com/tmap/routes/pedestrian?version=1",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            appKey: process.env.EXPO_PUBLIC_TMAP_KEY,
+          },
+          body: JSON.stringify(requestBody),
+        },
+      );
+
+      const data: TMapResponse = await res.json();
+
+      return data.features;
+    } catch (_error) {
+      throw new Error("경로 조회에 실패했습니다");
+    }
+  };
+
+  const getRoutes = async ({ start, end }: IDetailMapProps) => {
+    const data = await fetchRoutes({ start, end });
+
+    if (!data?.length) return [];
+
+    const pathCoords = data
+      .filter((item) => item.geometry.type === "LineString")
+      .flatMap((item) => item.geometry.coordinates)
+      .map(([lon, lat]) => ({ lat, lon }));
+
+    setPathCoords(pathCoords);
+
+    return pathCoords;
+  };
+
+  return { getRoutes, pathCoords };
+}

--- a/apps/dog-walk/hooks/usePedestrianRoutes.ts
+++ b/apps/dog-walk/hooks/usePedestrianRoutes.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { useState } from "react";
 
 interface IDetailMapProps {
@@ -44,19 +45,16 @@ export default function usePedestrianRoutes() {
     };
 
     try {
-      const res = await fetch(
+      const { data } = await axios.post<TMapResponse>(
         "https://apis.openapi.sk.com/tmap/routes/pedestrian?version=1",
+        requestBody,
         {
-          method: "POST",
           headers: {
             "Content-Type": "application/json",
             appKey: process.env.EXPO_PUBLIC_TMAP_KEY,
           },
-          body: JSON.stringify(requestBody),
         },
       );
-
-      const data: TMapResponse = await res.json();
 
       return data.features;
     } catch (_error) {

--- a/apps/dog-walk/types/displayType.ts
+++ b/apps/dog-walk/types/displayType.ts
@@ -1,0 +1,23 @@
+/**
+ * IconText 컴포넌트에서 사용되는 아이콘 타입
+ */
+export const IconTextType = {
+  MAP: "MAP",
+  CLOCK: "CLOCK",
+  STAR: "STAR",
+} as const;
+
+/**
+ * 상세 화면의 탭에서 사용되는 key 타입
+ */
+export const TabKeyType = {
+  /** 정보 탭 */
+  INFO: "INFO",
+  /** 지도 탭 */
+  MAP: "MAP",
+  /** 리뷰 탭 */
+  REVIEW: "REVIEW",
+} as const;
+
+export type IconTextType = keyof typeof IconTextType;
+export type TabKeyType = keyof typeof TabKeyType;


### PR DESCRIPTION
## 설명 (Description)

- gluestack-ui 기반의 토스트 UI 추가 & 이를 관리하는 커스텀 Toast 컴포넌트 추가
- Tmap 도보 경로를 조회할 수 있는 커스텀 훅 구현
- 기존 enum 기반의 IconText, TabKey 타입 리팩토링


## 스크린샷/동영상 (Screenshots/Videos)

- 토스트 UI
<img src="https://github.com/user-attachments/assets/8b4cab65-5e6d-4846-8656-c47bbffc2931" width="200px"/>


## 변경 내용 (Changes Made)

- [x] gluestack-ui 기반의 Toast 컴포넌트 추가
- [x] Toast UI를 관리하는 컴포넌트 구현
- [x]  Tmap 도보 경로 조회용 usePedestrianRoutes 훅 개발
- [x]  IconTextEnum, TabKeyEnum → const 객체 + 타입 별칭으로 변경
- [x]  변경된 타입에 맞게 기존 enum 사용처 리팩토링


## 테스트 방법 (How to Test)

cd dog-walk npx expo run:android


## 체크리스트 (Checklist)

- [x] Android에서 테스트 완료
- [ ] iOS에서 테스트 완료
- [ ] 웹에서 테스트 완료


