### PR TITLE
feat(country-tracker): ✨ 라이센스 자동 생성

### DIFF
--- a/apps/country-tracker/src/assets/licenses.json
+++ b/apps/country-tracker/src/assets/licenses.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2025-06-14T09:12:07.311Z",
+  "generated": "2025-06-14T09:30:16.696Z",
   "app": "country-tracker",
   "totalPackages": 67,
   "stats": {

--- a/apps/country-tracker/src/assets/licenses.json
+++ b/apps/country-tracker/src/assets/licenses.json
@@ -1,0 +1,568 @@
+{
+  "generated": "2025-06-14T09:12:07.311Z",
+  "app": "country-tracker",
+  "totalPackages": 67,
+  "stats": {
+    "local": 67,
+    "npm": 0,
+    "fallback": 0
+  },
+  "appVersion": "1.0.0",
+  "licenses": [
+    {
+      "name": "@babel/core",
+      "version": "7.27.1",
+      "license": "MIT",
+      "author": "The Babel Team (https://babel.dev/team)",
+      "description": "Babel compiler core.",
+      "repository": "https://github.com/babel/babel.git",
+      "homepage": "https://babel.dev/docs/en/next/babel-core"
+    },
+    {
+      "name": "@biomejs/biome",
+      "version": "1.9.4",
+      "license": "MIT OR Apache-2.0",
+      "author": "Emanuele Stoppa",
+      "description": "Biome is a toolchain for the web: formatter, linter and more",
+      "repository": "git+https://github.com/biomejs/biome.git",
+      "homepage": "https://biomejs.dev"
+    },
+    {
+      "name": "@expo/html-elements",
+      "version": "0.4.2",
+      "license": "MIT",
+      "author": "650 Industries, Inc.",
+      "description": "Universal semantic HTML React components for iOS, Android, web, and desktop",
+      "repository": "https://github.com/expo/expo.git",
+      "homepage": "https://github.com/expo/expo/tree/main/packages/html-elements"
+    },
+    {
+      "name": "@expo/vector-icons",
+      "version": "14.1.0",
+      "license": "MIT",
+      "author": "Brent Vatne",
+      "description": "Built-in support for popular icon fonts and the tooling to create your own Icon components from your font and glyph map. This is a wrapper around react-native-vector-icons to make it compatible with Expo.",
+      "repository": "https://github.com/expo/vector-icons.git",
+      "homepage": "https://expo.github.io/vector-icons"
+    },
+    {
+      "name": "@gluestack-ui/actionsheet",
+      "version": "0.2.53",
+      "description": "A universal headless actionsheet component for React Native, Next.js & React",
+      "repository": "git+https://github.com/gluestack/gluestack-ui.git",
+      "homepage": "https://github.com/gluestack/gluestack-ui/tree/main/packages/unstyled/actionsheet#readme"
+    },
+    {
+      "name": "@gluestack-ui/button",
+      "version": "1.0.14",
+      "description": "A universal headless Button component for React Native, Next.js & React",
+      "repository": "git+https://github.com/gluestack/gluestack-ui.git",
+      "homepage": "https://github.com/gluestack/gluestack-ui/tree/main/packages/unstyled/button#readme"
+    },
+    {
+      "name": "@gluestack-ui/divider",
+      "version": "0.1.10",
+      "description": "A universal headless Divider component for React Native, Next.js & React",
+      "repository": "git+https://github.com/gluestack/gluestack-ui.git",
+      "homepage": "https://github.com/gluestack/gluestack-ui/tree/main/packages/unstyled/divider#readme"
+    },
+    {
+      "name": "@gluestack-ui/fab",
+      "version": "0.1.28",
+      "description": "A universal headless fab component for React Native, Next.js & React",
+      "repository": "git+https://github.com/gluestack/gluestack-ui.git",
+      "homepage": "https://github.com/gluestack/gluestack-ui/tree/main/packages/unstyled/fab#readme"
+    },
+    {
+      "name": "@gluestack-ui/input",
+      "version": "0.1.38",
+      "description": "A universal headless input component for React Native, Next.js & React",
+      "repository": "git+https://github.com/gluestack/gluestack-ui.git",
+      "homepage": "https://github.com/gluestack/gluestack-ui/tree/main/packages/unstyled/input#readme"
+    },
+    {
+      "name": "@gluestack-ui/menu",
+      "version": "0.2.43",
+      "description": "A universal headless menu component for React Native, Next.js & React",
+      "repository": "git+https://github.com/gluestack/gluestack-ui.git",
+      "homepage": "https://github.com/gluestack/gluestack-ui/tree/main/packages/unstyled/menu#readme"
+    },
+    {
+      "name": "@gluestack-ui/nativewind-utils",
+      "version": "1.0.26",
+      "description": "A utility function package for @gluestack-ui/nativewind"
+    },
+    {
+      "name": "@gluestack-ui/overlay",
+      "version": "0.1.22",
+      "description": "A universal headless overlay component for React Native, Next.js & React",
+      "repository": "git+https://github.com/gluestack/gluestack-ui.git",
+      "homepage": "https://github.com/gluestack/gluestack-ui/tree/main/packages/unstyled/overlay#readme"
+    },
+    {
+      "name": "@gluestack-ui/select",
+      "version": "0.1.31",
+      "description": "A universal headless select component for React Native, Next.js & React",
+      "repository": "git+https://github.com/gluestack/gluestack-ui.git",
+      "homepage": "https://github.com/gluestack/gluestack-ui/tree/main/packages/unstyled/select#readme"
+    },
+    {
+      "name": "@gluestack-ui/switch",
+      "version": "0.1.29",
+      "description": "A universal headless Switch component for React Native, Next.js & React",
+      "repository": "git+https://github.com/gluestack/gluestack-ui.git",
+      "homepage": "https://github.com/gluestack/gluestack-ui/tree/main/packages/unstyled/switch#readme"
+    },
+    {
+      "name": "@gluestack-ui/toast",
+      "version": "1.0.9",
+      "description": "A universal headless toast component for React Native, Next.js & React",
+      "repository": "git+https://github.com/gluestack/gluestack-ui.git",
+      "homepage": "https://github.com/gluestack/gluestack-ui/tree/main/packages/unstyled/toast#readme"
+    },
+    {
+      "name": "@gorhom/bottom-sheet",
+      "version": "5.1.4",
+      "license": "MIT",
+      "author": "Mo Gorhom (https://gorhom.dev)",
+      "description": "A performant interactive bottom sheet with fully configurable options 🚀",
+      "repository": "https://github.com/gorhom/react-native-bottom-sheet",
+      "homepage": "https://gorhom.dev/react-native-bottom-sheet/"
+    },
+    {
+      "name": "@legendapp/motion",
+      "version": "2.4.0",
+      "license": "MIT",
+      "author": "Legend <contact@legendapp.com> (https://github.com/LegendApp)",
+      "description": "legend-motion",
+      "repository": "git+https://github.com/LegendApp/legend-motion.git",
+      "homepage": "https://github.com/LegendApp/legend-motion#readme"
+    },
+    {
+      "name": "@react-native-async-storage/async-storage",
+      "version": "1.23.1",
+      "license": "MIT",
+      "author": "Krzysztof Borowy <hello@krizzu.dev>",
+      "description": "Asynchronous, persistent, key-value storage system for React Native.",
+      "repository": "https://github.com/react-native-async-storage/async-storage.git",
+      "homepage": "https://github.com/react-native-async-storage/async-storage#readme"
+    },
+    {
+      "name": "@react-navigation/native",
+      "version": "6.1.18",
+      "license": "MIT",
+      "description": "React Native integration for React Navigation",
+      "repository": "https://github.com/react-navigation/react-navigation.git",
+      "homepage": "https://reactnavigation.org"
+    },
+    {
+      "name": "@reactuses/core",
+      "version": "5.0.23",
+      "license": "Unlicense",
+      "repository": "git+https://github.com/childrentime/reactuse.git",
+      "homepage": "https://www.reactuse.com/"
+    },
+    {
+      "name": "@sentry/react-native",
+      "version": "6.13.1",
+      "license": "MIT",
+      "author": "Sentry",
+      "description": "Official Sentry SDK for react-native",
+      "repository": "https://github.com/getsentry/sentry-react-native",
+      "homepage": "https://github.com/getsentry/sentry-react-native"
+    },
+    {
+      "name": "@t3-oss/env-core",
+      "version": "0.12.0",
+      "license": "MIT",
+      "author": "Julius Marminge",
+      "repository": "https://github.com/t3-oss/t3-env"
+    },
+    {
+      "name": "@testing-library/react-native",
+      "version": "12.9.0",
+      "license": "MIT",
+      "author": "Michał Pierzchała <thymikee@gmail.com> (https://github.com/thymikee), Maciej Jastrzębski <mdjastrzebski@gmail.com> (https://github.com/mdjastrzebski)",
+      "description": "Simple and complete React Native testing utilities that encourage good testing practices.",
+      "repository": "https://www.github.com/callstack/react-native-testing-library.git",
+      "homepage": "https://callstack.github.io/react-native-testing-library"
+    },
+    {
+      "name": "@types/jest",
+      "version": "29.5.14",
+      "license": "MIT",
+      "description": "TypeScript definitions for jest",
+      "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+      "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/jest"
+    },
+    {
+      "name": "@types/luxon",
+      "version": "3.6.2",
+      "license": "MIT",
+      "description": "TypeScript definitions for luxon",
+      "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+      "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/luxon"
+    },
+    {
+      "name": "@types/react",
+      "version": "18.2.79",
+      "license": "MIT",
+      "description": "TypeScript definitions for react",
+      "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+      "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react"
+    },
+    {
+      "name": "@types/react-test-renderer",
+      "version": "18.3.1",
+      "license": "MIT",
+      "description": "TypeScript definitions for react-test-renderer",
+      "repository": "https://github.com/DefinitelyTyped/DefinitelyTyped.git",
+      "homepage": "https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-test-renderer"
+    },
+    {
+      "name": "babel-plugin-module-resolver",
+      "version": "5.0.2",
+      "license": "MIT",
+      "author": "Tommy Leunen",
+      "description": "Module resolver plugin for Babel",
+      "repository": "https://github.com/tleunen/babel-plugin-module-resolver.git"
+    },
+    {
+      "name": "babel-plugin-transform-vite-meta-env",
+      "version": "1.0.3",
+      "license": "MIT",
+      "author": "Michael Peyper <mpeyper7@gmail.com>",
+      "description": "babel plugin that emulates vite's import.meta.env functionality",
+      "repository": "git+https://github.com/OpenSourceRaidGuild/babel-vite.git",
+      "homepage": "https://github.com/OpenSourceRaidGuild/babel-vite#readme"
+    },
+    {
+      "name": "clsx",
+      "version": "2.1.1",
+      "license": "MIT",
+      "author": "Luke Edwards",
+      "description": "A tiny (239B) utility for constructing className strings conditionally.",
+      "repository": "lukeed/clsx"
+    },
+    {
+      "name": "es-toolkit",
+      "version": "1.37.2",
+      "license": "MIT",
+      "description": "A state-of-the-art, high-performance JavaScript utility library with a small bundle size and strong type annotations.",
+      "repository": "https://github.com/toss/es-toolkit.git",
+      "homepage": "https://es-toolkit.slash.page"
+    },
+    {
+      "name": "expo",
+      "version": "51.0.39",
+      "license": "MIT",
+      "author": "Expo",
+      "description": "The Expo SDK",
+      "repository": "https://github.com/expo/expo.git",
+      "homepage": "https://github.com/expo/expo/tree/main/packages/expo"
+    },
+    {
+      "name": "expo-constants",
+      "version": "16.0.2",
+      "license": "MIT",
+      "author": "650 Industries, Inc.",
+      "description": "Provides system information that remains constant throughout the lifetime of your app.",
+      "repository": "https://github.com/expo/expo.git",
+      "homepage": "https://docs.expo.dev/versions/latest/sdk/constants/"
+    },
+    {
+      "name": "expo-font",
+      "version": "12.0.10",
+      "license": "MIT",
+      "author": "650 Industries, Inc.",
+      "description": "Load fonts at runtime and use them in React Native components.",
+      "repository": "https://github.com/expo/expo.git",
+      "homepage": "https://docs.expo.dev/versions/latest/sdk/font/"
+    },
+    {
+      "name": "expo-intent-launcher",
+      "version": "11.0.1",
+      "license": "MIT",
+      "author": "650 Industries, Inc.",
+      "description": "Provides a way to launch Android intents, e.g. opening a specific activity.",
+      "repository": "https://github.com/expo/expo.git",
+      "homepage": "https://docs.expo.dev/versions/latest/sdk/intent-launcher/"
+    },
+    {
+      "name": "expo-linking",
+      "version": "6.3.1",
+      "license": "MIT",
+      "author": "650 Industries, Inc.",
+      "description": "Create and open deep links universally",
+      "repository": "https://github.com/expo/expo.git",
+      "homepage": "https://docs.expo.dev/versions/latest/sdk/linking"
+    },
+    {
+      "name": "expo-localization",
+      "version": "15.0.3",
+      "license": "MIT",
+      "author": "650 Industries, Inc.",
+      "description": "Provides an interface for native user localization information.",
+      "repository": "https://github.com/expo/expo.git",
+      "homepage": "https://docs.expo.dev/versions/latest/sdk/localization/"
+    },
+    {
+      "name": "expo-location",
+      "version": "17.0.1",
+      "license": "MIT",
+      "author": "650 Industries, Inc.",
+      "description": "Allows reading geolocation information from the device. Your app can poll for the current location or subscribe to location update events.",
+      "repository": "https://github.com/expo/expo.git",
+      "homepage": "https://docs.expo.dev/versions/latest/sdk/location/"
+    },
+    {
+      "name": "expo-router",
+      "version": "3.5.24",
+      "license": "MIT",
+      "author": "650 Industries, Inc.",
+      "description": "Expo Router is a file-based router for React Native and web applications.",
+      "repository": "https://github.com/expo/expo.git",
+      "homepage": "https://docs.expo.dev/routing/introduction/"
+    },
+    {
+      "name": "expo-splash-screen",
+      "version": "0.27.7",
+      "license": "MIT",
+      "author": "650 Industries, Inc.",
+      "description": "Provides a module to allow keeping the native Splash Screen visible until you choose to hide it.",
+      "repository": "https://github.com/expo/expo.git",
+      "homepage": "https://docs.expo.dev/versions/latest/sdk/splash-screen/"
+    },
+    {
+      "name": "expo-status-bar",
+      "version": "1.12.1",
+      "license": "MIT",
+      "author": "650 Industries, Inc.",
+      "description": "Provides the same interface as the React Native StatusBar API, but with slightly different defaults to work great in Expo environments.",
+      "repository": "https://github.com/expo/expo.git",
+      "homepage": "https://docs.expo.dev/versions/latest/sdk/status-bar/"
+    },
+    {
+      "name": "expo-system-ui",
+      "version": "3.0.7",
+      "license": "MIT",
+      "author": "650 Industries, Inc.",
+      "description": "Interact with system UI elements",
+      "repository": "https://github.com/expo/expo.git",
+      "homepage": "https://docs.expo.dev/versions/latest/sdk/system-ui"
+    },
+    {
+      "name": "expo-task-manager",
+      "version": "11.8.2",
+      "license": "MIT",
+      "author": "650 Industries, Inc.",
+      "description": "Expo module that provides support for tasks that can run in the background.",
+      "repository": "https://github.com/expo/expo.git",
+      "homepage": "https://docs.expo.dev/versions/latest/sdk/task-manager/"
+    },
+    {
+      "name": "expo-web-browser",
+      "version": "13.0.3",
+      "license": "MIT",
+      "author": "650 Industries, Inc.",
+      "description": "Provides access to the system's web browser and supports handling redirects. On iOS, it uses SFSafariViewController or SFAuthenticationSession, depending on the method you call, and on Android it uses ChromeCustomTabs. As of iOS 11, SFSafariViewController no longer shares cookies with Safari, so if you are using WebBrowser for authentication you will want to use WebBrowser.openAuthSessionAsync, and if you just want to open a webpage (such as your app privacy policy), then use WebBrowser.openBrowserAsync.",
+      "repository": "https://github.com/expo/expo.git",
+      "homepage": "https://docs.expo.dev/versions/latest/sdk/webbrowser/"
+    },
+    {
+      "name": "i18n-js",
+      "version": "4.5.1",
+      "license": "MIT",
+      "author": "Nando Vieira <me@fnando.com>",
+      "description": "A small library to provide I18n on JavaScript.",
+      "repository": "https://github.com/fnando/i18n"
+    },
+    {
+      "name": "jest",
+      "version": "29.7.0",
+      "license": "MIT",
+      "description": "Delightful JavaScript Testing.",
+      "repository": "https://github.com/jestjs/jest.git",
+      "homepage": "https://jestjs.io/"
+    },
+    {
+      "name": "jest-expo",
+      "version": "51.0.4",
+      "license": "MIT",
+      "description": "A Jest preset to painlessly test your Expo / React Native apps.",
+      "repository": "git://github.com/expo/expo.git",
+      "homepage": "https://github.com/expo/expo/tree/main/packages/jest-expo"
+    },
+    {
+      "name": "jotai",
+      "version": "2.12.4",
+      "license": "MIT",
+      "author": "Daishi Kato",
+      "description": "👻 Primitive and flexible state management for React",
+      "repository": "git+https://github.com/pmndrs/jotai.git",
+      "homepage": "https://github.com/pmndrs/jotai"
+    },
+    {
+      "name": "jscodeshift",
+      "version": "0.15.2",
+      "license": "MIT",
+      "author": "Felix Kling",
+      "description": "A toolkit for JavaScript codemods",
+      "repository": "https://github.com/facebook/jscodeshift.git"
+    },
+    {
+      "name": "lucide-react-native",
+      "version": "0.511.0",
+      "license": "ISC",
+      "author": "Eric Fennis",
+      "description": "A Lucide icon library package for React Native applications.",
+      "repository": "https://github.com/lucide-icons/lucide.git",
+      "homepage": "https://lucide.dev"
+    },
+    {
+      "name": "luxon",
+      "version": "3.6.1",
+      "license": "MIT",
+      "author": "Isaac Cambron",
+      "description": "Immutable date wrapper",
+      "repository": "https://github.com/moment/luxon"
+    },
+    {
+      "name": "nativewind",
+      "version": "4.1.23",
+      "license": "MIT",
+      "author": "Mark Lawlor",
+      "description": "Use Tailwindcss in your cross-platform React Native applications",
+      "repository": "git+https://github.com/marklawlor/nativewind.git",
+      "homepage": "https://nativewind.dev"
+    },
+    {
+      "name": "prettier",
+      "version": "3.5.3",
+      "license": "MIT",
+      "author": "James Long",
+      "description": "Prettier is an opinionated code formatter",
+      "repository": "prettier/prettier",
+      "homepage": "https://prettier.io"
+    },
+    {
+      "name": "react",
+      "version": "18.2.0",
+      "license": "MIT",
+      "description": "React is a JavaScript library for building user interfaces.",
+      "repository": "https://github.com/facebook/react.git",
+      "homepage": "https://reactjs.org/"
+    },
+    {
+      "name": "react-dom",
+      "version": "18.2.0",
+      "license": "MIT",
+      "description": "React package for working with the DOM.",
+      "repository": "https://github.com/facebook/react.git",
+      "homepage": "https://reactjs.org/"
+    },
+    {
+      "name": "react-native",
+      "version": "0.74.5",
+      "license": "MIT",
+      "description": "A framework for building native apps using React",
+      "repository": "https://github.com/facebook/react-native.git",
+      "homepage": "https://reactnative.dev/"
+    },
+    {
+      "name": "react-native-gesture-handler",
+      "version": "2.16.2",
+      "license": "MIT",
+      "author": "Krzysztof Magiera",
+      "description": "Experimental implementation of a new declarative API for gesture handling in react-native",
+      "repository": "git+https://github.com/software-mansion/react-native-gesture-handler.git",
+      "homepage": "https://github.com/software-mansion/react-native-gesture-handler#readme"
+    },
+    {
+      "name": "react-native-maps",
+      "version": "1.23.7",
+      "license": "MIT",
+      "author": "Leland Richardson <leland.m.richardson@gmail.com>",
+      "description": "React Native Mapview component for iOS + Android",
+      "repository": "https://github.com/react-native-maps/react-native-maps",
+      "homepage": "https://github.com/react-native-maps/react-native-maps#readme"
+    },
+    {
+      "name": "react-native-reanimated",
+      "version": "3.10.1",
+      "license": "MIT",
+      "author": "Krzysztof Magiera",
+      "description": "More powerful alternative to Animated library for React Native.",
+      "repository": "git+https://github.com/software-mansion/react-native-reanimated.git",
+      "homepage": "https://github.com/software-mansion/react-native-reanimated#readme"
+    },
+    {
+      "name": "react-native-safe-area-context",
+      "version": "4.10.5",
+      "license": "MIT",
+      "author": "Janic Duplessis <janicduplessis@gmail.com>",
+      "description": "A flexible way to handle safe area, also works on Android and web.",
+      "repository": "https://github.com/th3rdwave/react-native-safe-area-context.git",
+      "homepage": "https://github.com/th3rdwave/react-native-safe-area-context#readme"
+    },
+    {
+      "name": "react-native-screens",
+      "version": "3.31.1",
+      "license": "MIT",
+      "author": "Krzysztof Magiera",
+      "description": "Native navigation primitives for your React Native app.",
+      "repository": "git+https://github.com/software-mansion/react-native-screens.git",
+      "homepage": "https://github.com/software-mansion/react-native-screens#readme"
+    },
+    {
+      "name": "react-native-svg",
+      "version": "15.12.0",
+      "license": "MIT",
+      "description": "SVG library for react-native",
+      "repository": "https://github.com/react-native-community/react-native-svg",
+      "homepage": "https://github.com/react-native-community/react-native-svg"
+    },
+    {
+      "name": "react-native-web",
+      "version": "0.19.13",
+      "license": "MIT",
+      "author": "Nicolas Gallagher",
+      "description": "React Native for Web",
+      "repository": "git://github.com/necolas/react-native-web.git"
+    },
+    {
+      "name": "tailwindcss",
+      "version": "3.4.17",
+      "license": "MIT",
+      "description": "A utility-first CSS framework for rapidly building custom user interfaces.",
+      "repository": "https://github.com/tailwindlabs/tailwindcss.git",
+      "homepage": "https://tailwindcss.com"
+    },
+    {
+      "name": "type-fest",
+      "version": "4.41.0",
+      "license": "(MIT OR CC0-1.0)",
+      "author": "Sindre Sorhus",
+      "description": "A collection of essential TypeScript types",
+      "repository": "sindresorhus/type-fest"
+    },
+    {
+      "name": "typescript",
+      "version": "5.8.3",
+      "license": "Apache-2.0",
+      "author": "Microsoft Corp.",
+      "description": "TypeScript is a language for application scale JavaScript development",
+      "repository": "https://github.com/microsoft/TypeScript.git",
+      "homepage": "https://www.typescriptlang.org/"
+    },
+    {
+      "name": "zod",
+      "version": "3.24.4",
+      "license": "MIT",
+      "author": "Colin McDonnell <colin@colinhacks.com>",
+      "description": "TypeScript-first schema declaration and validation library with static type inference",
+      "repository": "git+https://github.com/colinhacks/zod.git",
+      "homepage": "https://zod.dev"
+    }
+  ]
+}

--- a/apps/country-tracker/src/features/settings/components/license-screen.tsx
+++ b/apps/country-tracker/src/features/settings/components/license-screen.tsx
@@ -1,3 +1,4 @@
+import licensesData from "@/assets/licenses.json";
 import ParallaxScrollView from "@/components/ParallaxScrollView";
 import { Box } from "@/components/ui/box";
 import { Heading } from "@/components/ui/heading";
@@ -13,372 +14,9 @@ interface LicenseItem {
   license?: string;
   author?: string;
   description?: string;
+  repository?: string;
+  homepage?: string;
 }
-
-// 주요 패키지들의 라이센스 정보 (실제로는 package.json에서 동적으로 생성해야 함)
-const licenses: LicenseItem[] = [
-  {
-    name: "react",
-    license: "MIT",
-    author: "Meta Platforms, Inc.",
-    description:
-      "A declarative, efficient, and flexible JavaScript library for building user interfaces.",
-  },
-  {
-    name: "react-native",
-    license: "MIT",
-    author: "Meta Platforms, Inc.",
-    description: "A framework for building native apps with React.",
-  },
-  {
-    name: "react-dom",
-    license: "MIT",
-    author: "Meta Platforms, Inc.",
-    description: "React package for working with the DOM.",
-  },
-  {
-    name: "expo",
-    license: "MIT",
-    author: "Expo",
-    description:
-      "An open-source platform for making universal native apps with React.",
-  },
-  {
-    name: "expo-router",
-    license: "MIT",
-    author: "Expo",
-    description: "File-based router for universal React Native apps.",
-  },
-  {
-    name: "expo-constants",
-    license: "MIT",
-    author: "Expo",
-    description:
-      "Provides system information that remains constant throughout the lifetime of your app.",
-  },
-  {
-    name: "expo-font",
-    license: "MIT",
-    author: "Expo",
-    description:
-      "Load fonts at runtime and use them in React Native components.",
-  },
-  {
-    name: "expo-linking",
-    license: "MIT",
-    author: "Expo",
-    description:
-      "Provides utilities for your app to interact with other installed apps using deep links.",
-  },
-  {
-    name: "expo-localization",
-    license: "MIT",
-    author: "Expo",
-    description: "Provides access to device locale information.",
-  },
-  {
-    name: "expo-location",
-    license: "MIT",
-    author: "Expo",
-    description: "Provides access to reading geolocation information.",
-  },
-  {
-    name: "expo-splash-screen",
-    license: "MIT",
-    author: "Expo",
-    description: "Provides an API to configure the native splash screen.",
-  },
-  {
-    name: "expo-status-bar",
-    license: "MIT",
-    author: "Expo",
-    description:
-      "Provides the same interface as the React Native StatusBar API.",
-  },
-  {
-    name: "expo-system-ui",
-    license: "MIT",
-    author: "Expo",
-    description: "Provides access to system UI styling APIs.",
-  },
-  {
-    name: "expo-task-manager",
-    license: "MIT",
-    author: "Expo",
-    description: "Provides an API that allows you to define and run tasks.",
-  },
-  {
-    name: "expo-web-browser",
-    license: "MIT",
-    author: "Expo",
-    description: "Provides access to the system's web browser.",
-  },
-  {
-    name: "expo-intent-launcher",
-    license: "MIT",
-    author: "Expo",
-    description: "Provides a way to launch Android intents.",
-  },
-
-  // UI Libraries
-  {
-    name: "@gluestack-ui/actionsheet",
-    license: "MIT",
-    author: "GlueStack",
-    description: "A universal actionsheet component for React Native.",
-  },
-  {
-    name: "@gluestack-ui/button",
-    license: "MIT",
-    author: "GlueStack",
-    description: "A universal button component for React Native.",
-  },
-  {
-    name: "@gluestack-ui/divider",
-    license: "MIT",
-    author: "GlueStack",
-    description: "A universal divider component for React Native.",
-  },
-  {
-    name: "@gluestack-ui/fab",
-    license: "MIT",
-    author: "GlueStack",
-    description:
-      "A universal floating action button component for React Native.",
-  },
-  {
-    name: "@gluestack-ui/input",
-    license: "MIT",
-    author: "GlueStack",
-    description: "A universal input component for React Native.",
-  },
-  {
-    name: "@gluestack-ui/menu",
-    license: "MIT",
-    author: "GlueStack",
-    description: "A universal menu component for React Native.",
-  },
-  {
-    name: "@gluestack-ui/nativewind-utils",
-    license: "MIT",
-    author: "GlueStack",
-    description: "Utilities for NativeWind integration with GlueStack UI.",
-  },
-  {
-    name: "@gluestack-ui/overlay",
-    license: "MIT",
-    author: "GlueStack",
-    description: "A universal overlay component for React Native.",
-  },
-  {
-    name: "@gluestack-ui/select",
-    license: "MIT",
-    author: "GlueStack",
-    description: "A universal select component for React Native.",
-  },
-  {
-    name: "@gluestack-ui/switch",
-    license: "MIT",
-    author: "GlueStack",
-    description: "A universal switch component for React Native.",
-  },
-  {
-    name: "@gluestack-ui/toast",
-    license: "MIT",
-    author: "GlueStack",
-    description: "A universal toast component for React Native.",
-  },
-  {
-    name: "nativewind",
-    license: "MIT",
-    author: "NativeWind",
-    description: "Tailwind CSS for React Native.",
-  },
-  {
-    name: "tailwindcss",
-    license: "MIT",
-    author: "Tailwind Labs",
-    description: "A utility-first CSS framework.",
-  },
-
-  // State Management & Utils
-  {
-    name: "jotai",
-    license: "MIT",
-    author: "Jotai",
-    description: "Primitive and flexible state management for React.",
-  },
-  {
-    name: "zod",
-    license: "MIT",
-    author: "Colin McDonnell",
-    description:
-      "TypeScript-first schema validation with static type inference.",
-  },
-  {
-    name: "luxon",
-    license: "MIT",
-    author: "Isaac Cambron",
-    description: "A library for working with dates and times in JS.",
-  },
-  {
-    name: "es-toolkit",
-    license: "MIT",
-    author: "es-toolkit",
-    description:
-      "A modern JavaScript utility library that's 2-3x faster and up to 97% smaller.",
-  },
-  {
-    name: "clsx",
-    license: "MIT",
-    author: "Luke Edwards",
-    description:
-      "A tiny utility for constructing className strings conditionally.",
-  },
-
-  // Navigation & Gestures
-  {
-    name: "@react-navigation/native",
-    license: "MIT",
-    author: "React Navigation",
-    description: "Routing and navigation for your React Native apps.",
-  },
-  {
-    name: "react-native-gesture-handler",
-    license: "MIT",
-    author: "Software Mansion",
-    description:
-      "Declarative API exposing platform native touch and gesture system to React Native.",
-  },
-  {
-    name: "react-native-reanimated",
-    license: "MIT",
-    author: "Software Mansion",
-    description: "React Native's Animated library reimplemented.",
-  },
-  {
-    name: "react-native-safe-area-context",
-    license: "MIT",
-    author: "React Native Safe Area Context",
-    description: "A flexible way to handle safe area insets in JS.",
-  },
-  {
-    name: "react-native-screens",
-    license: "MIT",
-    author: "Software Mansion",
-    description: "Native navigation primitives for your React Native app.",
-  },
-
-  // Maps & Location
-  {
-    name: "react-native-maps",
-    license: "MIT",
-    author: "Airbnb",
-    description: "React Native Mapview component for iOS + Android.",
-  },
-  {
-    name: "@gorhom/bottom-sheet",
-    license: "MIT",
-    author: "Mo Gorhom",
-    description:
-      "A performant interactive bottom sheet with fully configurable options.",
-  },
-
-  // Icons & SVG
-  {
-    name: "lucide-react-native",
-    license: "ISC",
-    author: "Lucide",
-    description: "Beautiful & consistent icon toolkit made by the community.",
-  },
-  {
-    name: "@expo/vector-icons",
-    license: "MIT",
-    author: "Expo",
-    description:
-      "Built-in support for popular icon fonts and the tooling to create your own Icon components.",
-  },
-  {
-    name: "react-native-svg",
-    license: "MIT",
-    author: "React Native SVG",
-    description: "SVG library for React Native.",
-  },
-
-  // Animation & Motion
-  {
-    name: "@legendapp/motion",
-    license: "MIT",
-    author: "Legend",
-    description: "A declarative animations library for React Native.",
-  },
-
-  // Internationalization
-  {
-    name: "i18n-js",
-    license: "MIT",
-    author: "Fnando Vieira",
-    description:
-      "It's a small library to provide the I18n translations on the JavaScript.",
-  },
-
-  // Storage & async
-  {
-    name: "@react-native-async-storage/async-storage",
-    license: "MIT",
-    author: "React Native Async Storage",
-    description:
-      "An asynchronous, persistent, key-value storage system for React Native.",
-  },
-
-  // React Utilities
-  {
-    name: "@reactuses/core",
-    license: "MIT",
-    author: "ReactUses",
-    description: "Collection of essential React Hooks.",
-  },
-
-  // Environment & Config
-  {
-    name: "@t3-oss/env-core",
-    license: "MIT",
-    author: "T3 OSS",
-    description: "Validate your environment variables with a simple schema.",
-  },
-
-  // Error Tracking
-  {
-    name: "@sentry/react-native",
-    license: "MIT",
-    author: "Sentry",
-    description: "Official Sentry SDK for React Native.",
-  },
-
-  // HTML Elements
-  {
-    name: "@expo/html-elements",
-    license: "MIT",
-    author: "Expo",
-    description: "Primitive HTML elements for universal React apps.",
-  },
-
-  // Web
-  {
-    name: "react-native-web",
-    license: "MIT",
-    author: "Nicolas Gallagher",
-    description: "React Native Components and APIs for the Web.",
-  },
-
-  // Code Transformation
-  {
-    name: "jscodeshift",
-    license: "MIT",
-    author: "Facebook",
-    description: "A JavaScript codemod toolkit.",
-  },
-];
 
 export default function LicenseScreen() {
   const [
@@ -397,8 +35,14 @@ export default function LicenseScreen() {
     "primary-600",
   ]);
 
-  const openNpmPage = (packageName: string) => {
-    const url = `https://www.npmjs.com/package/${packageName}`;
+  const licenses: LicenseItem[] = licensesData.licenses;
+
+  const openPackagePage = (item: LicenseItem) => {
+    // Try homepage first, then repository, then npm
+    const url =
+      item.homepage ||
+      item.repository?.replace(/^git\+/, "").replace(/\.git$/, "") ||
+      `https://www.npmjs.com/package/${item.name}`;
     Linking.openURL(url);
   };
 
@@ -410,7 +54,7 @@ export default function LicenseScreen() {
         key={item.name}
         className={`p-4 ${!isLast ? "border-b" : ""}`}
         style={{ borderBottomColor: borderColor }}
-        onPress={() => openNpmPage(item.name)}
+        onPress={() => openPackagePage(item)}
       >
         <Box className="flex-row items-start justify-between">
           <Box className="mr-3 flex-1">
@@ -426,7 +70,7 @@ export default function LicenseScreen() {
                   className="ml-2 text-sm"
                   style={{ color: secondaryTextColor }}
                 >
-                  {item.version}
+                  v{item.version}
                 </Text>
               )}
             </Box>
@@ -488,7 +132,11 @@ export default function LicenseScreen() {
             {i18n.t("settings.license.libraries")}
           </Heading>
           <Text className="mt-1 text-sm" style={{ color: secondaryTextColor }}>
-            {i18n.t("settings.license.tap-to-view")}
+            {i18n.t("settings.license.tap-to-view")} •{" "}
+            {licensesData.totalPackages} packages
+          </Text>
+          <Text className="mt-1 text-xs" style={{ color: secondaryTextColor }}>
+            Generated: {new Date(licensesData.generated).toLocaleDateString()}
           </Text>
         </Box>
 

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "typescript": "catalog:",
     "yaml": "^2.8.0"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.12.1",
   "engines": {
     "node": ">=22",
-    "pnpm": ">=9"
+    "pnpm": ">=10"
   }
 }

--- a/turbo/generators/config.ts
+++ b/turbo/generators/config.ts
@@ -1,8 +1,10 @@
 import type { PlopTypes } from "@turbo/gen";
 import createModule from "./set-generator/create-module";
+import generateLicense from "./set-generator/generate-license";
 import linkPackageToApps from "./set-generator/link-package";
 
 export default function generator(plop: PlopTypes.NodePlopAPI): void {
   createModule(plop);
   linkPackageToApps(plop);
+  generateLicense(plop);
 }

--- a/turbo/generators/set-generator/generate-license.ts
+++ b/turbo/generators/set-generator/generate-license.ts
@@ -257,24 +257,4 @@ export default function generateLicense(plop: PlopTypes.NodePlopAPI) {
       },
     ],
   });
-
-  // Keep interactive-only generator for explicit use
-  plop.setGenerator("license-interactive", {
-    description:
-      "Generate licenses.json file for an app (interactive selection only)",
-    prompts: [
-      {
-        type: "list",
-        name: "appName",
-        message: "Which app would you like to generate licenses for?",
-        choices: getApps,
-      },
-    ],
-    actions: [
-      async (answers: object) => {
-        const typedAnswers = answers as GeneratorAnswers;
-        return await generateLicenseForApp(typedAnswers.appName);
-      },
-    ],
-  });
 }

--- a/turbo/generators/set-generator/generate-license.ts
+++ b/turbo/generators/set-generator/generate-license.ts
@@ -138,29 +138,6 @@ export default function generateLicense(plop: PlopTypes.NodePlopAPI) {
     return apps.filter((app) => !app.startsWith("."));
   };
 
-  // Helper function to get app name from process args
-  const getAppNameFromArgs = (): string | undefined => {
-    const argv = process.argv;
-
-    // Look for JSON argument that contains args
-    for (const arg of argv) {
-      try {
-        const parsed = JSON.parse(arg);
-        if (
-          parsed.args &&
-          Array.isArray(parsed.args) &&
-          parsed.args.length > 0
-        ) {
-          return parsed.args[0];
-        }
-      } catch {
-        // Not JSON, continue
-      }
-    }
-
-    return undefined;
-  };
-
   // Helper function to generate license for a given app name
   const generateLicenseForApp = async (appName: string): Promise<string> => {
     // Validate app exists
@@ -242,15 +219,10 @@ export default function generateLicense(plop: PlopTypes.NodePlopAPI) {
     ],
     actions: [
       async (answers: object) => {
-        // Try args first, then answers
-        const argAppName = getAppNameFromArgs();
-        const appName = argAppName || (answers as GeneratorAnswers).appName;
+        const { appName } = answers as GeneratorAnswers;
 
         if (!appName) {
-          const apps = await getApps();
-          throw new Error(
-            `App name is required. Usage: turbo gen license --args <app-name>\nAvailable apps: ${apps.join(", ")}`,
-          );
+          throw new Error("App name is required.");
         }
 
         return await generateLicenseForApp(appName);

--- a/turbo/generators/set-generator/generate-license.ts
+++ b/turbo/generators/set-generator/generate-license.ts
@@ -1,0 +1,280 @@
+import type { PlopTypes } from "@turbo/gen";
+import type { PackageJson } from "type-fest";
+
+import { execSync } from "node:child_process";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+interface LicenseInfo {
+  name: string;
+  version?: string;
+  license?: string;
+  author?: string;
+  description?: string;
+  repository?: string;
+  homepage?: string;
+  source?: "local" | "npm" | "fallback";
+}
+
+function fetchPackageInfoFromNpm(depName: string): LicenseInfo | null {
+  try {
+    const npmInfo = execSync(`npm view ${depName} --json`, {
+      encoding: "utf8",
+      timeout: 15000,
+    });
+    const pkgInfo = JSON.parse(npmInfo);
+
+    return {
+      name: depName,
+      version: pkgInfo.version,
+      license: pkgInfo.license,
+      author:
+        typeof pkgInfo.author === "string"
+          ? pkgInfo.author
+          : pkgInfo.author?.name || pkgInfo.author?.email,
+      description: pkgInfo.description,
+      repository:
+        typeof pkgInfo.repository === "string"
+          ? pkgInfo.repository
+          : pkgInfo.repository?.url,
+      homepage: pkgInfo.homepage,
+      source: "npm",
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function getPackageInfoFromLocal(
+  depName: string,
+): Promise<LicenseInfo | null> {
+  try {
+    const depPackageJsonPath = resolve(`node_modules/${depName}/package.json`);
+    const content = await readFile(depPackageJsonPath, "utf8");
+    const depPkg = JSON.parse(content) as PackageJson;
+
+    return {
+      name: depName,
+      version: depPkg.version,
+      license: depPkg.license as string,
+      author:
+        typeof depPkg.author === "string"
+          ? depPkg.author
+          : depPkg.author?.name || depPkg.author?.email,
+      description: depPkg.description,
+      repository:
+        typeof depPkg.repository === "string"
+          ? depPkg.repository
+          : depPkg.repository?.url,
+      homepage: depPkg.homepage,
+      source: "local",
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function processPackageDependencies(
+  dependencies: Record<string, string>,
+): Promise<LicenseInfo[]> {
+  const licenses: LicenseInfo[] = [];
+  const processedPackages = new Set<string>();
+
+  for (const [depName, depVersion] of Object.entries(dependencies)) {
+    // Skip duplicates and scoped packages that are already processed
+    if (processedPackages.has(depName)) continue;
+    processedPackages.add(depName);
+
+    // Try local first (faster), then npm registry
+    let licenseInfo = await getPackageInfoFromLocal(depName);
+
+    if (!licenseInfo) {
+      licenseInfo = fetchPackageInfoFromNpm(depName);
+    }
+
+    if (!licenseInfo) {
+      // Add minimal info as fallback
+      licenseInfo = {
+        name: depName,
+        version: depVersion.replace(/[\^~>=<]|[\d.]+/g, "").trim() || "unknown",
+        license: "Unknown",
+        source: "fallback",
+      };
+    }
+
+    licenses.push(licenseInfo);
+  }
+
+  return licenses;
+}
+
+function filterAndCleanDependencies(
+  packageJson: PackageJson,
+): Record<string, string> {
+  const allDeps = {
+    ...packageJson.dependencies,
+    ...packageJson.devDependencies,
+  };
+
+  // Filter out local workspace packages and clean up versions
+  const cleanedDeps: Record<string, string> = {};
+
+  for (const [name, version] of Object.entries(allDeps || {})) {
+    if (!name.startsWith("@infinite-loop-factory/") && version) {
+      cleanedDeps[name] = version;
+    }
+  }
+
+  return cleanedDeps;
+}
+
+interface GeneratorAnswers {
+  appName: string;
+}
+
+export default function generateLicense(plop: PlopTypes.NodePlopAPI) {
+  const getApps = async () => {
+    const apps = await readdir(resolve("apps"));
+    return apps.filter((app) => !app.startsWith("."));
+  };
+
+  // Helper function to get app name from process args
+  const getAppNameFromArgs = (): string | undefined => {
+    const argv = process.argv;
+
+    // Look for JSON argument that contains args
+    for (const arg of argv) {
+      try {
+        const parsed = JSON.parse(arg);
+        if (
+          parsed.args &&
+          Array.isArray(parsed.args) &&
+          parsed.args.length > 0
+        ) {
+          return parsed.args[0];
+        }
+      } catch {
+        // Not JSON, continue
+      }
+    }
+
+    return undefined;
+  };
+
+  // Helper function to generate license for a given app name
+  const generateLicenseForApp = async (appName: string): Promise<string> => {
+    // Validate app exists
+    const apps = await getApps();
+    if (!apps.includes(appName)) {
+      throw new Error(
+        `App '${appName}' not found. Available apps: ${apps.join(", ")}`,
+      );
+    }
+
+    try {
+      // Read app's package.json to get dependencies
+      const appPackageJsonPath = resolve(`apps/${appName}/package.json`);
+      const packageJsonContent = await readFile(appPackageJsonPath, "utf8");
+      const packageJson = JSON.parse(packageJsonContent) as PackageJson;
+
+      // Filter and clean dependencies
+      const dependencies = filterAndCleanDependencies(packageJson);
+
+      // Process dependencies
+      const licenses = await processPackageDependencies(dependencies);
+
+      // Sort licenses alphabetically by name
+      licenses.sort((a, b) => a.name.localeCompare(b.name));
+
+      // Group by source for statistics
+      const stats = {
+        local: licenses.filter((l) => l.source === "local").length,
+        npm: licenses.filter((l) => l.source === "npm").length,
+        fallback: licenses.filter((l) => l.source === "fallback").length,
+      };
+
+      // Ensure assets directory exists (try src/assets first, then assets)
+      let assetsDir = resolve(`apps/${appName}/src/assets`);
+
+      try {
+        await mkdir(assetsDir, { recursive: true });
+      } catch {
+        // If src/assets fails, try just assets
+        assetsDir = resolve(`apps/${appName}/assets`);
+        await mkdir(assetsDir, { recursive: true });
+      }
+
+      // Prepare license data
+      const licenseData = {
+        generated: new Date().toISOString(),
+        app: appName,
+        totalPackages: licenses.length,
+        stats,
+        appVersion: packageJson.version || "1.0.0",
+        licenses: licenses.map(({ source, ...license }) => license), // Remove source from output
+      };
+
+      // Write licenses.json file
+      const licensesFilePath = join(assetsDir, "licenses.json");
+      await writeFile(
+        licensesFilePath,
+        JSON.stringify(licenseData, null, 2),
+        "utf8",
+      );
+
+      return `Generated licenses.json for ${appName} (${licenses.length} packages: ${stats.local} local, ${stats.npm} npm, ${stats.fallback} fallback)`;
+    } catch (error) {
+      throw new Error(`Error generating licenses for ${appName}: ${error}`);
+    }
+  };
+
+  // Smart generator that handles both args and prompts
+  plop.setGenerator("license", {
+    description:
+      "Generate licenses.json file for an app (use --args <app-name> or select interactively)",
+    prompts: [
+      {
+        type: "list",
+        name: "appName",
+        message: "Which app would you like to generate licenses for?",
+        choices: getApps,
+      },
+    ],
+    actions: [
+      async (answers: object) => {
+        // Try args first, then answers
+        const argAppName = getAppNameFromArgs();
+        const appName = argAppName || (answers as GeneratorAnswers).appName;
+
+        if (!appName) {
+          const apps = await getApps();
+          throw new Error(
+            `App name is required. Usage: turbo gen license --args <app-name>\nAvailable apps: ${apps.join(", ")}`,
+          );
+        }
+
+        return await generateLicenseForApp(appName);
+      },
+    ],
+  });
+
+  // Keep interactive-only generator for explicit use
+  plop.setGenerator("license-interactive", {
+    description:
+      "Generate licenses.json file for an app (interactive selection only)",
+    prompts: [
+      {
+        type: "list",
+        name: "appName",
+        message: "Which app would you like to generate licenses for?",
+        choices: getApps,
+      },
+    ],
+    actions: [
+      async (answers: object) => {
+        const typedAnswers = answers as GeneratorAnswers;
+        return await generateLicenseForApp(typedAnswers.appName);
+      },
+    ],
+  });
+}


### PR DESCRIPTION
## 설명 (Description)

- 라이센스 파일 src/{app}/assets/ 에 자동생성되게 했습니다.

## 스크린샷/동영상 (Screenshots/Videos)

<img width="621" alt="Screenshot 2025-06-14 at 18 19 04" src="https://github.com/user-attachments/assets/da2f3464-7f22-4bbf-87b3-24d14668a610" />

<img width="632" alt="Screenshot 2025-06-14 at 18 22 20" src="https://github.com/user-attachments/assets/65f6d729-8f8a-4abb-b69b-4b87fe890701" />

## 변경 내용 (Changes Made)

- 하드코딩 된 라이세스 지웠습니다.
- pnpm turbo gen license 하면 원하는 앱에 라이센스 파일 생성할 수 있습니다.
- pnpm 버전 업그레이드했습니다. `volta install pnpm` 이나 `brew install pnpm` 해주시면 됩니다.

## 테스트 방법 (How to Test)

- pnpm turbo gen license

## 체크리스트 (Checklist)

- [ ] iOS에서 테스트 완료
- [ ] Android에서 테스트 완료
- [x] 웹에서 테스트 완료
- [ ] 관련 문서 업데이트 완료 (필요시)