### PR TITLE
feat: ✨ add reset, play, and queue buttons after artist selection

### DIFF
--- a/apps/playlist/app/(tabs)/index.tsx
+++ b/apps/playlist/app/(tabs)/index.tsx
@@ -1,4 +1,6 @@
 import Button from "@/components/Buttons";
+import CircleButton from "@/components/CircleButton";
+import IconButton from "@/components/IconButton";
 import ImageViewer from "@/components/ImageViewer";
 import { useState } from "react";
 import {
@@ -15,6 +17,7 @@ const ARTISTS = ["Jennie", "Lisa", "Rosé", "Jisoo", "IU"];
 export default function Index() {
   const [modalVisible, setModalVisible] = useState(false);
   const [selectedArtist, setSelectedArtist] = useState("Jennie");
+  const [showArtistOptions, setShowArtistOptions] = useState(false);
 
   const images: Record<string, ImageSourcePropType> = {
     Jennie: require("../../assets/images/jennie.png"),
@@ -27,6 +30,19 @@ export default function Index() {
   const selectArtist = (artist: string) => {
     setSelectedArtist(artist);
     setModalVisible(false);
+    setShowArtistOptions(true);
+  };
+
+  const onReset = () => {
+    setShowArtistOptions(false);
+  };
+
+  const onPlay = () => {
+    // i will implement this later
+  };
+
+  const onShowQueue = async () => {
+    // i will implement this later
   };
 
   return (
@@ -41,13 +57,26 @@ export default function Index() {
           </Text>
         </View>
       </View>
-
-      <View className="flex-[0.33] items-center">
-        <Button label="Choose a mix" theme="primary" />
-        <Button
-          label="Choose an artist"
-          onPress={() => setModalVisible(true)}
-        />
+      <View className="flex-[0.33]">
+        {showArtistOptions ? (
+          <View className="flex-row">
+            <IconButton icon="refresh" label="Reset" onPress={onReset} />
+            <CircleButton onPress={onPlay} />
+            <IconButton
+              icon="playlist-play"
+              label="Queue"
+              onPress={onShowQueue}
+            />
+          </View>
+        ) : (
+          <>
+            <Button label="Choose a mix" theme="primary" />
+            <Button
+              label="Choose an artist"
+              onPress={() => setModalVisible(true)}
+            />
+          </>
+        )}
       </View>
 
       <Modal

--- a/apps/playlist/components/Buttons.tsx
+++ b/apps/playlist/components/Buttons.tsx
@@ -15,7 +15,7 @@ type Props = {
 export default function Button({ label, theme, onPress }: Props) {
   if (theme === "primary") {
     return (
-      <View className="mx-5 h-[68px] w-80 items-center justify-center rounded-xl border-4 border-[#ffd33d] p-1">
+      <View className="mx-5 h-[68px] w-80 items-center justify-center rounded-xl border-4 border-[#1ED760] p-1">
         <Pressable
           className="h-full w-full flex-row items-center justify-center rounded-lg bg-white"
           onPress={() => alert("You pressed a button.")}

--- a/apps/playlist/components/CircleButton.tsx
+++ b/apps/playlist/components/CircleButton.tsx
@@ -1,0 +1,19 @@
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
+import { Pressable, View } from "react-native";
+
+type Props = {
+  onPress: () => void;
+};
+
+export default function CircleButton({ onPress }: Props) {
+  return (
+    <View className="mx-[60px] h-[72px] w-[72px] rounded-full bg-[#1ED760] p-1">
+      <Pressable
+        className="flex-1 items-center justify-center rounded-full"
+        onPress={onPress}
+      >
+        <MaterialIcons name="play-arrow" size={50} color="#25292e" />
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/playlist/components/IconButton.tsx
+++ b/apps/playlist/components/IconButton.tsx
@@ -1,0 +1,17 @@
+import MaterialIcons from "@expo/vector-icons/MaterialIcons";
+import { Pressable, Text } from "react-native";
+
+type Props = {
+  icon: keyof typeof MaterialIcons.glyphMap;
+  label: string;
+  onPress: () => void;
+};
+
+export default function IconButton({ icon, label, onPress }: Props) {
+  return (
+    <Pressable className="items-center justify-center" onPress={onPress}>
+      <MaterialIcons name={icon} size={24} color="#fff" />
+      <Text className="mt-3 text-white">{label}</Text>
+    </Pressable>
+  );
+}


### PR DESCRIPTION
## 설명 (Description)

- add reset, play, and queue buttons after artist selection

## 스크린샷/동영상 (Screenshots/Videos)

<img width="456" alt="Screenshot 2025-06-15 at 11 46 03 am" src="https://github.com/user-attachments/assets/685584ab-91b6-4658-88a0-f987def09416" />

## 체크리스트 (Checklist)

- [x] iOS에서 테스트 완료
- [x] Android에서 테스트 완료
- [ ] 웹에서 테스트 완료
- [ ] 관련 문서 업데이트 완료 (필요시)