### PR TITLE
feat: ✨ add mini player UI component and integrate into tab layout

### DIFF
--- a/apps/playlist/app/(tabs)/_layout.tsx
+++ b/apps/playlist/app/(tabs)/_layout.tsx
@@ -1,49 +1,72 @@
 import { Ionicons } from "@expo/vector-icons";
 import { Tabs } from "expo-router";
+import { View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import MiniPlayer from "@/components/MiniPlayer";
 
-export default function TapsLayout() {
+export default function TabsLayout() {
+  const insets = useSafeAreaInsets();
+
   return (
-    <Tabs
-      screenOptions={{
-        tabBarActiveTintColor: "#F2F2F2",
-        headerStyle: {
-          backgroundColor: "#0D0D0D",
-        },
-        headerShadowVisible: false,
-        headerTintColor: "#FFFFFE",
-        tabBarStyle: {
-          backgroundColor: "#0D0D0D",
-        },
-      }}
-    >
-      <Tabs.Screen
-        name="index"
-        options={{
-          tabBarLabel: "Home",
-          headerTitle: "Playlist",
-          tabBarIcon: ({ focused, color }) => (
-            <Ionicons
-              name={focused ? "home-sharp" : "home-outline"}
-              color={color}
-              size={23}
-            />
-          ),
+    <View style={{ flex: 1 }}>
+      <Tabs
+        screenOptions={{
+          tabBarActiveTintColor: "#F2F2F2",
+          headerStyle: {
+            backgroundColor: "#0D0D0D",
+          },
+          headerShadowVisible: false,
+          headerTintColor: "#FFFFFE",
+          tabBarStyle: {
+            backgroundColor: "#0D0D0D",
+          },
         }}
-      />
-      <Tabs.Screen
-        name="search"
-        options={{
-          tabBarLabel: "Search",
-          headerTitle: "Search",
-          tabBarIcon: ({ focused, color }) => (
-            <Ionicons
-              name={focused ? "search" : "search-outline"}
-              color={color}
-              size={23}
-            />
-          ),
+      >
+        <Tabs.Screen
+          name="index"
+          options={{
+            tabBarLabel: "Home",
+            headerTitle: "Playlist",
+            tabBarIcon: ({ focused, color }) => (
+              <Ionicons
+                color={color}
+                name={focused ? "home-sharp" : "home-outline"}
+                size={23}
+              />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="search"
+          options={{
+            tabBarLabel: "Search",
+            headerTitle: "Search",
+            tabBarIcon: ({ focused, color }) => (
+              <Ionicons
+                color={color}
+                name={focused ? "search" : "search-outline"}
+                size={23}
+              />
+            ),
+          }}
+        />
+      </Tabs>
+      <View
+        style={{
+          bottom: insets.bottom + 55,
+          left: 0,
+          right: 0,
         }}
-      />
-    </Tabs>
+      >
+        <MiniPlayer
+          artist="Jennie"
+          currentTrack="SOLO"
+          isPlaying={true}
+          onPlayPause={() => {
+            // TODO: implement play/pause functionality
+          }}
+        />
+      </View>
+    </View>
   );
 }

--- a/apps/playlist/components/MiniPlayer.tsx
+++ b/apps/playlist/components/MiniPlayer.tsx
@@ -1,0 +1,35 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Image, Text, TouchableOpacity, View } from "react-native";
+
+interface MiniPlayerProps {
+  currentTrack: string;
+  artist: string;
+  isPlaying: boolean;
+  onPlayPause: () => void;
+}
+
+export default function MiniPlayer({
+  currentTrack,
+  artist,
+  isPlaying,
+  onPlayPause,
+}: MiniPlayerProps) {
+  return (
+    <View className="absolute right-0 bottom-0 left-0 mx-3 flex-row items-center justify-between rounded-xl bg-[#1a1a1a] p-3 shadow-lg">
+      <View className="flex-row items-center">
+        <Image
+          className="h-12 w-12 rounded-md"
+          source={require("../assets/images/jennie.png")}
+        />
+        <View className="ml-3">
+          <Text className="font-semibold text-white">{currentTrack}</Text>
+          <Text className="text-gray-400 text-sm">{artist}</Text>
+        </View>
+      </View>
+
+      <TouchableOpacity onPress={onPlayPause}>
+        <Ionicons color="white" name={isPlaying ? "pause" : "play"} size={25} />
+      </TouchableOpacity>
+    </View>
+  );
+}


### PR DESCRIPTION
## 설명 (Description)

- MiniPlayer UI 만든 후 탭 네비게이션 위에 표시되도록 구현

## 스크린샷/동영상 (Screenshots/Videos)

<img width="461" height="905" alt="Screenshot 2025-08-31 at 1 52 33 pm" src="https://github.com/user-attachments/assets/4d418348-0c0e-4d71-8875-2571f2a19479" />

## 체크리스트 (Checklist)

- [x] iOS에서 테스트 완료
- [x] Android에서 테스트 완료
- [ ] 웹에서 테스트 완료

## 추가 정보 (Additional Context)

- 웹은 점점 깨지는 중
- git push 시 특정 프로젝트만 테스트 가능할까요?