### PR TITLE
feat: ✨ replace mini player animation with bottom sheet

### DIFF
--- a/apps/playlist/app/(tabs)/_layout.tsx
+++ b/apps/playlist/app/(tabs)/_layout.tsx
@@ -1,68 +1,66 @@
+import "react-native-gesture-handler";
+
 import { Ionicons } from "@expo/vector-icons";
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 import { Tabs } from "expo-router";
 import { View } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
 import MiniPlayer from "@/components/MiniPlayer";
 import { PlayerProvider } from "@/contexts/PlayerContext";
 
 export default function TabsLayout() {
-  const insets = useSafeAreaInsets();
-
   return (
-    <PlayerProvider>
-      <View style={{ flex: 1 }}>
-        <Tabs
-          screenOptions={{
-            tabBarActiveTintColor: "#F2F2F2",
-            headerStyle: {
-              backgroundColor: "#0D0D0D",
-            },
-            headerShadowVisible: false,
-            headerTintColor: "#FFFFFE",
-            tabBarStyle: {
-              backgroundColor: "#0D0D0D",
-            },
-          }}
-        >
-          <Tabs.Screen
-            name="index"
-            options={{
-              tabBarLabel: "Home",
-              headerTitle: "Playlist",
-              tabBarIcon: ({ focused, color }) => (
-                <Ionicons
-                  color={color}
-                  name={focused ? "home-sharp" : "home-outline"}
-                  size={23}
-                />
-              ),
-            }}
-          />
-          <Tabs.Screen
-            name="search"
-            options={{
-              tabBarLabel: "Search",
-              headerTitle: "Search",
-              tabBarIcon: ({ focused, color }) => (
-                <Ionicons
-                  color={color}
-                  name={focused ? "search" : "search-outline"}
-                  size={23}
-                />
-              ),
-            }}
-          />
-        </Tabs>
-        <View
-          style={{
-            bottom: insets.bottom + 55,
-            left: 0,
-            right: 0,
-          }}
-        >
-          <MiniPlayer />
-        </View>
-      </View>
-    </PlayerProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <PlayerProvider>
+        <BottomSheetModalProvider>
+          <View style={{ flex: 1 }}>
+            <Tabs
+              screenOptions={{
+                tabBarActiveTintColor: "#F2F2F2",
+                headerStyle: {
+                  backgroundColor: "#0D0D0D",
+                },
+                headerShadowVisible: false,
+                headerTintColor: "#FFFFFE",
+                tabBarStyle: {
+                  backgroundColor: "#0D0D0D",
+                },
+              }}
+            >
+              <Tabs.Screen
+                name="index"
+                options={{
+                  tabBarLabel: "Home",
+                  headerTitle: "Playlist",
+                  tabBarIcon: ({ focused, color }) => (
+                    <Ionicons
+                      color={color}
+                      name={focused ? "home-sharp" : "home-outline"}
+                      size={23}
+                    />
+                  ),
+                }}
+              />
+              <Tabs.Screen
+                name="search"
+                options={{
+                  tabBarLabel: "Search",
+                  headerTitle: "Search",
+                  tabBarIcon: ({ focused, color }) => (
+                    <Ionicons
+                      color={color}
+                      name={focused ? "search" : "search-outline"}
+                      size={23}
+                    />
+                  ),
+                }}
+              />
+            </Tabs>
+
+            <MiniPlayer />
+          </View>
+        </BottomSheetModalProvider>
+      </PlayerProvider>
+    </GestureHandlerRootView>
   );
 }

--- a/apps/playlist/app/(tabs)/index.tsx
+++ b/apps/playlist/app/(tabs)/index.tsx
@@ -102,6 +102,7 @@ export default function Index() {
                       selectedArtist,
                       firstTrack.title,
                       firstTrack.file,
+                      images[selectedArtist],
                     );
                   }
                 }
@@ -167,7 +168,12 @@ export default function Index() {
                 <TouchableOpacity
                   className="mb-2 rounded bg-gray-800 p-3"
                   onPress={() => {
-                    playTrack(selectedArtist, item.title, item.file);
+                    playTrack(
+                      selectedArtist,
+                      item.title,
+                      item.file,
+                      images[selectedArtist],
+                    );
                     setQueueModalVisible(false);
                   }}
                 >

--- a/apps/playlist/components/MiniPlayer.tsx
+++ b/apps/playlist/components/MiniPlayer.tsx
@@ -1,28 +1,125 @@
 import { Ionicons } from "@expo/vector-icons";
-import { Image, Text, TouchableOpacity, View } from "react-native";
+import BottomSheet, { BottomSheetView } from "@gorhom/bottom-sheet";
+import { useMemo, useRef } from "react";
+import { FlatList, Image, Text, TouchableOpacity, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { usePlayer } from "@/contexts/PlayerContext";
 
 export default function MiniPlayer() {
-  const { currentTrack, artist, isPlaying, togglePlayPause } = usePlayer();
+  const {
+    currentTrack,
+    artist,
+    image,
+    isPlaying,
+    togglePlayPause,
+    recentlyPlayed,
+    playTrack,
+  } = usePlayer();
+  const bottomSheetRef = useRef<BottomSheet>(null);
+  const insets = useSafeAreaInsets();
 
-  if (!(currentTrack && artist)) return null;
+  // 바텀시트의 스냅 포인트 설정: 미니 플레이어(90px), 전체 화면(90%)
+  const snapPoints = useMemo(() => [90, "90%"], []);
+
+  // 트랙이 없으면 렌더링하지 않음
+  if (!(currentTrack && artist)) {
+    return null;
+  }
 
   return (
-    <View className="absolute right-0 bottom-0 left-0 mx-3 flex-row items-center justify-between rounded-xl bg-[#1a1a1a] p-3 shadow-lg">
-      <View className="flex-row items-center">
-        <Image
-          className="h-12 w-12 rounded-md"
-          source={require("../assets/images/jennie.png")}
-        />
-        <View className="ml-3">
-          <Text className="font-semibold text-white">{currentTrack}</Text>
-          <Text className="text-gray-400 text-sm">{artist}</Text>
-        </View>
-      </View>
+    <BottomSheet
+      backgroundStyle={{ backgroundColor: "#1a1a1a" }}
+      enablePanDownToClose={false}
+      handleIndicatorStyle={{ backgroundColor: "#666" }}
+      index={0}
+      ref={bottomSheetRef}
+      snapPoints={snapPoints}
+    >
+      <BottomSheetView style={{ flex: 1, paddingHorizontal: 16 }}>
+        {/* === 미니 플레이어 뷰 === */}
+        <View className="flex-row items-center justify-between pb-4">
+          <TouchableOpacity
+            activeOpacity={0.9}
+            className="flex-1 flex-row items-center"
+            onPress={() => bottomSheetRef.current?.expand()}
+          >
+            <Image
+              className="h-12 w-12 rounded-md"
+              source={image ?? require("../assets/images/jennie.png")}
+            />
+            <View className="ml-3 flex-1">
+              <Text className="font-semibold text-white" numberOfLines={1}>
+                {currentTrack}
+              </Text>
+              <Text className="text-gray-400 text-sm" numberOfLines={1}>
+                {artist}
+              </Text>
+            </View>
+          </TouchableOpacity>
 
-      <TouchableOpacity onPress={togglePlayPause}>
-        <Ionicons color="white" name={isPlaying ? "pause" : "play"} size={25} />
-      </TouchableOpacity>
-    </View>
+          <TouchableOpacity className="ml-3" onPress={togglePlayPause}>
+            <Ionicons
+              color="white"
+              name={isPlaying ? "pause" : "play"}
+              size={28}
+            />
+          </TouchableOpacity>
+        </View>
+
+        {/* === 전체 플레이어 뷰 === */}
+        <View className="flex-1">
+          {/* 앨범 아트 & 트랙 정보 */}
+          <View className="mb-6 items-center">
+            <Image
+              className="mb-6 h-64 w-64 rounded-2xl"
+              source={image ?? require("../assets/images/jennie.png")}
+            />
+            <Text className="text-center font-bold text-2xl text-white">
+              {currentTrack}
+            </Text>
+            <Text className="text-base text-gray-400">{artist}</Text>
+          </View>
+
+          {/* 재생 컨트롤 */}
+          <View className="mb-8 items-center">
+            <TouchableOpacity
+              className="h-16 w-16 items-center justify-center rounded-full bg-white"
+              onPress={togglePlayPause}
+            >
+              <Ionicons
+                color="black"
+                name={isPlaying ? "pause" : "play"}
+                size={32}
+              />
+            </TouchableOpacity>
+          </View>
+
+          {/* 최근 재생 목록 */}
+          <View className="flex-1">
+            <Text className="mb-3 font-semibold text-lg text-white">
+              Recently Played
+            </Text>
+            <FlatList
+              contentContainerStyle={{ paddingBottom: insets.bottom + 20 }}
+              data={recentlyPlayed}
+              keyExtractor={(item) => `${item.artist}-${item.track}`}
+              renderItem={({ item }) => (
+                <TouchableOpacity
+                  className="mb-2 rounded-lg bg-gray-800 p-3"
+                  onPress={() => {
+                    playTrack(item.artist, item.track, item.file);
+                    bottomSheetRef.current?.snapToIndex(0);
+                  }}
+                >
+                  <Text className="font-medium text-white">{item.track}</Text>
+                  <Text className="text-gray-400 text-sm">{item.artist}</Text>
+                </TouchableOpacity>
+              )}
+              showsVerticalScrollIndicator={false}
+            />
+          </View>
+        </View>
+      </BottomSheetView>
+    </BottomSheet>
   );
 }

--- a/apps/playlist/contexts/PlayerContext.tsx
+++ b/apps/playlist/contexts/PlayerContext.tsx
@@ -1,17 +1,32 @@
+import type { ImageSourcePropType } from "react-native";
+
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Audio, type AVPlaybackSource } from "expo-av";
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
+
+interface RecentlyPlayedItem {
+  artist: string;
+  track: string;
+  file: AVPlaybackSource;
+  image?: ImageSourcePropType;
+}
 
 interface PlayerContextType {
   currentTrack: string | null;
   artist: string | null;
+  image: ImageSourcePropType | null;
   isPlaying: boolean;
   playTrack: (
     artist: string,
     track: string,
     file: AVPlaybackSource,
+    image?: ImageSourcePropType,
   ) => Promise<void>;
   togglePlayPause: () => Promise<void>;
+  recentlyPlayed: RecentlyPlayedItem[];
 }
+
+const STORAGE_KEY = "recentlyPlayedTracks";
 
 const PlayerContext = createContext<PlayerContextType | undefined>(undefined);
 
@@ -19,24 +34,54 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
   const [sound, setSound] = useState<Audio.Sound | null>(null);
   const [currentTrack, setCurrentTrack] = useState<string | null>(null);
   const [artist, setArtist] = useState<string | null>(null);
+  const [image, setImage] = useState<ImageSourcePropType | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
+  const [recentlyPlayed, setRecentlyPlayed] = useState<RecentlyPlayedItem[]>(
+    [],
+  );
+
+  // ✅ 앱 시작 시 AsyncStorage에서 최근 재생 목록 불러오기
+  useEffect(() => {
+    (async () => {
+      const saved = await AsyncStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        setRecentlyPlayed(JSON.parse(saved));
+      }
+    })();
+  }, []);
 
   const playTrack = async (
     artistName: string,
     trackName: string,
     file: AVPlaybackSource,
+    img?: ImageSourcePropType,
   ) => {
     try {
       if (sound) {
         await sound.stopAsync();
         await sound.unloadAsync();
       }
+
       const { sound: newSound } = await Audio.Sound.createAsync(file);
       setSound(newSound);
       setCurrentTrack(trackName);
       setArtist(artistName);
+      setImage(img ?? null);
+
       await newSound.playAsync();
       setIsPlaying(true);
+
+      // ✅ 최근 재생 목록 업데이트 + 저장
+      setRecentlyPlayed((prev) => {
+        const updated = [
+          { artist: artistName, track: trackName, file, image: img },
+          ...prev.filter((t) => t.track !== trackName),
+        ].slice(0, 10);
+
+        AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+
+        return updated;
+      });
     } catch (e) {
       console.error("playTrack error", e);
     }
@@ -55,7 +100,15 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
 
   return (
     <PlayerContext.Provider
-      value={{ currentTrack, artist, isPlaying, playTrack, togglePlayPause }}
+      value={{
+        currentTrack,
+        artist,
+        image,
+        isPlaying,
+        playTrack,
+        togglePlayPause,
+        recentlyPlayed,
+      }}
     >
       {children}
     </PlayerContext.Provider>


### PR DESCRIPTION
## 설명 (Description)

- mini player 확장 bottom sheet로 구현

## 스크린샷/동영상 (Screenshots/Videos)
<img width="464" height="883" alt="Screenshot 2025-11-09 at 10 08 28 am" src="https://github.com/user-attachments/assets/2635d555-ba6f-470f-b758-641272b6f16d" />

## 체크리스트 (Checklist)

- [x] iOS에서 테스트 완료
- [x] Android에서 테스트 완료
- [ ] 웹에서 테스트 완료

## 추가 정보 (Additional Context)

- 디자인 좀더 손봐야 함
- 미니플레이어 -> 메인플레이어 싱크
- 확장 클릭 동작 추가
