### PR TITLE
feat(shake-it): 검색 반경 조절 기능 추가 및 검색 결과 랜덤화

### DIFF
--- a/apps/shake-it/src/app/index.tsx
+++ b/apps/shake-it/src/app/index.tsx
@@ -1,16 +1,19 @@
 import { MaterialIcons } from "@expo/vector-icons";
 import { LinearGradient } from "expo-linear-gradient";
 import { Accelerometer } from "expo-sensors";
-import { memo, useCallback, useEffect, useRef } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { Animated, Easing, Linking, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { RestaurantResultModal } from "@/components/restaurant-result-modal";
+import { SearchRadiusModal } from "@/components/search-radius-modal";
 import { ShakeHomeFooter } from "@/components/shake-home-footer";
 import { ShakeHomeHeader } from "@/components/shake-home-header";
 import { ShakeHomeHero } from "@/components/shake-home-hero";
 import { APP_CONFIG } from "@/constants/config";
 import { useLocation } from "@/hooks/use-location";
 import { useRestaurantRecommendation } from "@/hooks/use-restaurant-recommendation";
+import { useSearchRadius } from "@/hooks/use-search-radius";
+import { formatSearchRadius } from "@/utils/search-radius";
 
 const C = {
   primary: "#3d6bf5",
@@ -277,6 +280,11 @@ export default function HomeScreen() {
   const rippleStyle = useRippleAnimation();
   const { address, location, refreshLocation } = useLocation();
   const {
+    radius,
+    isLoading: isSearchRadiusLoading,
+    setRadius,
+  } = useSearchRadius();
+  const {
     isRecommending,
     isSelectingRestaurant,
     rouletteCategories,
@@ -287,14 +295,25 @@ export default function HomeScreen() {
     recommendRestaurant,
     clearRecommendation,
   } = useRestaurantRecommendation();
+  const [isRadiusModalVisible, setIsRadiusModalVisible] = useState(false);
 
   useEffect(() => {
-    refreshLocation();
+    void refreshLocation();
   }, [refreshLocation]);
 
   const handleRecommendRestaurant = useCallback(async () => {
-    await recommendRestaurant(location, refreshLocation);
-  }, [location, recommendRestaurant, refreshLocation]);
+    await recommendRestaurant(
+      location,
+      refreshLocation,
+      isSearchRadiusLoading ? APP_CONFIG.DEFAULT_SEARCH_RADIUS : radius,
+    );
+  }, [
+    isSearchRadiusLoading,
+    location,
+    radius,
+    recommendRestaurant,
+    refreshLocation,
+  ]);
 
   // Shake gesture detection
   useEffect(() => {
@@ -331,6 +350,22 @@ export default function HomeScreen() {
     clearRecommendation();
   }, [clearRecommendation]);
 
+  const handleOpenRadiusModal = useCallback(() => {
+    setIsRadiusModalVisible(true);
+  }, []);
+
+  const handleCloseRadiusModal = useCallback(() => {
+    setIsRadiusModalVisible(false);
+  }, []);
+
+  const handleSelectRadius = useCallback(
+    async (nextRadius: number) => {
+      await setRadius(nextRadius);
+      setIsRadiusModalVisible(false);
+    },
+    [setRadius],
+  );
+
   const handleOpenMap = useCallback(async () => {
     if (!recommendedRestaurant?.placeUrl) {
       return;
@@ -346,7 +381,11 @@ export default function HomeScreen() {
 
   return (
     <SafeAreaView className="flex-1 bg-white">
-      <ShakeHomeHeader address={address} />
+      <ShakeHomeHeader
+        address={address}
+        onPressRadius={handleOpenRadiusModal}
+        radiusLabel={formatSearchRadius(radius)}
+      />
       <ShakeHomeHero
         phoneIllustration={<PhoneIllustration />}
         pulseStyle={pulseStyle}
@@ -369,6 +408,13 @@ export default function HomeScreen() {
         rouletteCategories={rouletteCategories}
         rouletteIndex={rouletteIndex}
         visible={Boolean(recommendedRestaurant)}
+      />
+      <SearchRadiusModal
+        onClose={handleCloseRadiusModal}
+        onSelect={handleSelectRadius}
+        options={APP_CONFIG.SEARCH_RADIUS_OPTIONS}
+        selectedRadius={radius}
+        visible={isRadiusModalVisible}
       />
     </SafeAreaView>
   );

--- a/apps/shake-it/src/components/external-link.tsx
+++ b/apps/shake-it/src/components/external-link.tsx
@@ -1,20 +1,19 @@
-import type { Href } from "expo-router";
 import type { ComponentProps } from "react";
 
 import { Link } from "expo-router";
 import { openBrowserAsync } from "expo-web-browser";
 import { Platform } from "react-native";
 
-type Props = Omit<ComponentProps<typeof Link>, "href"> & { href: string };
+type Props = ComponentProps<typeof Link>;
 
 export function ExternalLink({ href, ...rest }: Props) {
   return (
     <Link
       target="_blank"
       {...rest}
-      href={href as Href<string>}
+      href={href}
       onPress={async (event) => {
-        if (Platform.OS !== "web") {
+        if (Platform.OS !== "web" && typeof href === "string") {
           // Prevent the default behavior of linking to the default browser on native.
           event.preventDefault();
           // Open the link in an in-app browser.

--- a/apps/shake-it/src/components/search-radius-modal.tsx
+++ b/apps/shake-it/src/components/search-radius-modal.tsx
@@ -1,0 +1,102 @@
+import { MaterialIcons } from "@expo/vector-icons";
+import { Modal, Pressable, Text, View } from "react-native";
+import { formatSearchRadius } from "@/utils/search-radius";
+
+interface SearchRadiusModalProps {
+  visible: boolean;
+  selectedRadius: number;
+  options: readonly number[];
+  onSelect: (radius: number) => void | Promise<void>;
+  onClose: () => void;
+}
+
+export function SearchRadiusModal({
+  visible,
+  selectedRadius,
+  options,
+  onSelect,
+  onClose,
+}: SearchRadiusModalProps) {
+  return (
+    <Modal
+      animationType="fade"
+      onRequestClose={onClose}
+      transparent
+      visible={visible}
+    >
+      <View className="flex-1 justify-end bg-black/45 px-4 pb-6">
+        <Pressable className="absolute inset-0" onPress={onClose} />
+
+        <View className="rounded-[28px] bg-white px-5 pt-5 pb-4">
+          <View className="mb-4 flex-row items-center justify-between">
+            <View>
+              <Text className="font-bold text-[#191F28] text-[20px]">
+                검색 반경
+              </Text>
+              <Text className="mt-1 text-slate-500 text-sm">
+                주변 맛집을 찾을 범위를 선택하세요
+              </Text>
+            </View>
+            <Pressable
+              accessibilityLabel="검색 반경 선택 닫기"
+              className="h-9 w-9 items-center justify-center rounded-full bg-slate-100"
+              onPress={onClose}
+            >
+              <MaterialIcons color="#64748b" name="close" size={20} />
+            </Pressable>
+          </View>
+
+          <View className="gap-3">
+            {options.map((option) => {
+              const isSelected = option === selectedRadius;
+
+              return (
+                <Pressable
+                  accessibilityLabel={`${formatSearchRadius(option)} 반경 선택`}
+                  accessibilityRole="button"
+                  className="flex-row items-center justify-between rounded-2xl border px-4 py-4"
+                  key={option}
+                  onPress={() => {
+                    void onSelect(option);
+                  }}
+                  style={{
+                    borderColor: isSelected ? "#3366FF" : "#E2E8F0",
+                    backgroundColor: isSelected ? "#EFF6FF" : "#FFFFFF",
+                  }}
+                >
+                  <View>
+                    <Text
+                      className="font-semibold text-base"
+                      style={{ color: isSelected ? "#1D4ED8" : "#191F28" }}
+                    >
+                      {formatSearchRadius(option)}
+                    </Text>
+                    <Text className="mt-1 text-slate-500 text-sm">
+                      반경 {option}m 내 음식점 검색
+                    </Text>
+                  </View>
+                  {isSelected ? (
+                    <MaterialIcons
+                      color="#3366FF"
+                      name="check-circle"
+                      size={22}
+                    />
+                  ) : (
+                    <View className="h-[22px] w-[22px] rounded-full border border-slate-300" />
+                  )}
+                </Pressable>
+              );
+            })}
+          </View>
+
+          <Pressable
+            className="mt-4 h-12 items-center justify-center rounded-2xl bg-slate-100"
+            onPress={onClose}
+          >
+            <Text className="font-semibold text-slate-600">취소</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/apps/shake-it/src/components/shake-home-header.tsx
+++ b/apps/shake-it/src/components/shake-home-header.tsx
@@ -8,23 +8,36 @@ const C = {
 
 interface ShakeHomeHeaderProps {
   address: string;
+  radiusLabel: string;
+  onPressRadius: () => void;
 }
 
-export function ShakeHomeHeader({ address }: ShakeHomeHeaderProps) {
+export function ShakeHomeHeader({
+  address,
+  radiusLabel,
+  onPressRadius,
+}: ShakeHomeHeaderProps) {
   return (
     <View className="flex-row items-center justify-between px-5 pb-4">
-      <Pressable className="flex-row items-center gap-1.5">
-        <Text
-          className="font-bold text-xl"
-          style={{ color: C.textMain, letterSpacing: -0.5 }}
-        >
-          {address || "위치 확인 중..."}
-        </Text>
-        <MaterialIcons
-          color={C.textMain}
-          name="keyboard-arrow-down"
-          size={24}
-        />
+      <Pressable className="gap-1" onPress={onPressRadius}>
+        <View className="flex-row items-center gap-1.5">
+          <Text
+            className="font-bold text-xl"
+            style={{ color: C.textMain, letterSpacing: -0.5 }}
+          >
+            {address || "위치 확인 중..."}
+          </Text>
+          <MaterialIcons
+            color={C.textMain}
+            name="keyboard-arrow-down"
+            size={24}
+          />
+        </View>
+        <View className="self-start rounded-full bg-[#EFF6FF] px-3 py-1">
+          <Text className="font-medium text-[#3366FF] text-xs">
+            검색 반경 {radiusLabel}
+          </Text>
+        </View>
       </Pressable>
 
       <Pressable

--- a/apps/shake-it/src/constants/config.ts
+++ b/apps/shake-it/src/constants/config.ts
@@ -7,13 +7,16 @@ export const APP_CONFIG = {
   SHAKE_COOLDOWN: 1000,
   // 기본 최소 별점
   DEFAULT_MIN_RATING: 3.5,
-  // 검색 반경 (미터)
-  SEARCH_RADIUS: 1000,
+  // 기본 검색 반경 (미터)
+  DEFAULT_SEARCH_RADIUS: 1000,
+  // 검색 반경 프리셋 (미터)
+  SEARCH_RADIUS_OPTIONS: [500, 1000, 1500, 2000],
   // 네이버 API 검색 결과 개수
   SEARCH_DISPLAY_COUNT: 20,
 } as const;
 
 export const STORAGE_KEYS = {
+  SEARCH_RADIUS: "@search_radius",
   USER_SETTINGS: "@user_settings",
   VISIT_HISTORY: "@visit_history",
 } as const;

--- a/apps/shake-it/src/hooks/use-restaurant-recommendation.ts
+++ b/apps/shake-it/src/hooks/use-restaurant-recommendation.ts
@@ -2,6 +2,7 @@ import type { KakaoRestaurant } from "@/services/kakao-api";
 import type { Location } from "@/types";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { APP_CONFIG } from "@/constants/config";
 import { searchNearbyRestaurants } from "@/services/kakao-api";
 
 const ROULETTE_INTERVAL_MS = 70;
@@ -148,7 +149,11 @@ export function useRestaurantRecommendation() {
   );
 
   const recommendRestaurant = useCallback(
-    async (location: Location | null, refreshLocation: RefreshLocation) => {
+    async (
+      location: Location | null,
+      refreshLocation: RefreshLocation,
+      radius: number = APP_CONFIG.DEFAULT_SEARCH_RADIUS,
+    ) => {
       if (isRecommending || isSelectingRestaurant) {
         return;
       }
@@ -166,6 +171,11 @@ export function useRestaurantRecommendation() {
         const restaurants = await searchNearbyRestaurants(
           currentLocation.latitude,
           currentLocation.longitude,
+          APP_CONFIG.SEARCH_RADIUS_OPTIONS.includes(
+            radius as (typeof APP_CONFIG.SEARCH_RADIUS_OPTIONS)[number],
+          )
+            ? radius
+            : APP_CONFIG.DEFAULT_SEARCH_RADIUS,
         );
         if (restaurants.length === 0) {
           setRecommendationError("주변에서 추천할 음식점을 찾지 못했습니다.");

--- a/apps/shake-it/src/hooks/use-restaurant-recommendation.ts
+++ b/apps/shake-it/src/hooks/use-restaurant-recommendation.ts
@@ -152,7 +152,7 @@ export function useRestaurantRecommendation() {
     async (
       location: Location | null,
       refreshLocation: RefreshLocation,
-      radius: number = APP_CONFIG.DEFAULT_SEARCH_RADIUS,
+      radius = APP_CONFIG.DEFAULT_SEARCH_RADIUS,
     ) => {
       if (isRecommending || isSelectingRestaurant) {
         return;
@@ -177,6 +177,7 @@ export function useRestaurantRecommendation() {
             ? radius
             : APP_CONFIG.DEFAULT_SEARCH_RADIUS,
         );
+
         if (restaurants.length === 0) {
           setRecommendationError("주변에서 추천할 음식점을 찾지 못했습니다.");
           setRecommendedRestaurant(null);

--- a/apps/shake-it/src/hooks/use-search-radius.ts
+++ b/apps/shake-it/src/hooks/use-search-radius.ts
@@ -1,0 +1,70 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useCallback, useEffect, useState } from "react";
+import { APP_CONFIG, STORAGE_KEYS } from "@/constants/config";
+import { formatSearchRadius } from "@/utils/search-radius";
+
+function normalizeSearchRadius(value: unknown) {
+  return APP_CONFIG.SEARCH_RADIUS_OPTIONS.includes(
+    value as (typeof APP_CONFIG.SEARCH_RADIUS_OPTIONS)[number],
+  )
+    ? (value as number)
+    : APP_CONFIG.DEFAULT_SEARCH_RADIUS;
+}
+
+export function useSearchRadius() {
+  const [radius, setRadiusState] = useState<number>(
+    APP_CONFIG.DEFAULT_SEARCH_RADIUS,
+  );
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadRadius() {
+      try {
+        const storedValue = await AsyncStorage.getItem(
+          STORAGE_KEYS.SEARCH_RADIUS,
+        );
+        if (!(isMounted && storedValue)) {
+          return;
+        }
+
+        const parsedValue = Number.parseInt(storedValue, 10);
+        setRadiusState(normalizeSearchRadius(parsedValue));
+      } catch (error) {
+        console.error("Failed to load search radius:", error);
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    loadRadius();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const setRadius = useCallback(async (nextRadius: number) => {
+    const normalizedRadius = normalizeSearchRadius(nextRadius);
+
+    try {
+      await AsyncStorage.setItem(
+        STORAGE_KEYS.SEARCH_RADIUS,
+        normalizedRadius.toString(),
+      );
+      setRadiusState(normalizedRadius);
+    } catch (error) {
+      console.error("Failed to save search radius:", error);
+    }
+  }, []);
+
+  return {
+    formatSearchRadius,
+    radius,
+    isLoading,
+    setRadius,
+  };
+}

--- a/apps/shake-it/src/services/kakao-api.ts
+++ b/apps/shake-it/src/services/kakao-api.ts
@@ -141,6 +141,7 @@ export async function searchNearbyRestaurants(
       category_group_code: "FD6",
       x: longitude.toString(),
       y: latitude.toString(),
+      page: String(Math.floor(Math.random() * 5) + 1),
       radius: radius.toString(),
       sort: "distance",
       size: "15",

--- a/apps/shake-it/src/utils/search-radius.ts
+++ b/apps/shake-it/src/utils/search-radius.ts
@@ -1,0 +1,8 @@
+export function formatSearchRadius(radius: number) {
+  if (radius < 1000) {
+    return `${radius}m`;
+  }
+
+  const kilometer = radius / 1000;
+  return Number.isInteger(kilometer) ? `${kilometer}km` : `${kilometer}km`;
+}


### PR DESCRIPTION
## 설명 (Description)

- 검색 반경을 사용자가 직접 조절할 수 있도록 기능을 추가했습니다. Kakao Local API 요청 시 page 파라미터를 랜덤으로 설정하여 다양한 검색 결과가 노출되도록 개선했습니다.

## 관련 이슈 (Related Issues)

- 없음

## 스크린샷/동영상 (Screenshots/Videos)

| 화면 |
|---|
| <img width="1170" height="2532" alt="simulator_screenshot_3D4C55DE-559E-49F7-87B5-8C803FBF5CAA" src="https://github.com/user-attachments/assets/068d61d1-602b-48c0-8636-dcafdaa22b4d" /> | 


## 변경 내용 (Changes Made)

- 코드에서 변경된 부분을 자세히 설명해주세요.
  - [x] 홈 헤더에 현재 검색 반경 표시 UI 추가
  - [x] 검색 반경 표시 UI 탭 시 검색 반경 선택 모달 추가
  - [x] Kakao Local API 요청 시 page 파라미터를 랜덤 값으로 설정하여
검색 결과를 무작위로 가져오도록 개선

## 테스트 방법 (How to Test)

1. 검색 영역 반경 선택
- 홈 상단 검색 반경 표시 영역 탭
- 검색 반경을 500m, 1km, 1.5km, 2km 중 하나로 변경
- 반경 선택 후 실행 시 정상적으로 음식점이 추천되는지 확인

## 체크리스트 (Checklist)

- [x] iOS에서 테스트 완료
- [x] Android에서 테스트 완료

