### PR TITLE
feat(dog-walk): 반려견 및 산책 코스 삭제 기능 추가

### DIFF
--- a/apps/dog-walk/api/reactQuery/dogs/useDeleteDog.ts
+++ b/apps/dog-walk/api/reactQuery/dogs/useDeleteDog.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/api/supabaseClient";
+import { queryKeys } from "../queryKeys";
+
+const deleteDog = async (dogId: number) => {
+  const { error } = await supabase
+    .from("dogs")
+    .update({ deleted_at: new Date() })
+    .eq("id", dogId);
+
+  if (error) throw error;
+};
+
+export const useDeleteDog = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (dogId: number) => deleteDog(dogId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [queryKeys.dogs.findDogs] });
+    },
+  });
+};

--- a/apps/dog-walk/api/reactQuery/dogs/useFindDogs.ts
+++ b/apps/dog-walk/api/reactQuery/dogs/useFindDogs.ts
@@ -9,6 +9,7 @@ const fetchDogs = async (userId: string) => {
     .from("dogs")
     .select("*")
     .eq("user_id", userId)
+    .is("deleted_at", null)
     .order("created_at", { ascending: true });
 
   if (error) throw error;

--- a/apps/dog-walk/app/(screens)/detail/[id].tsx
+++ b/apps/dog-walk/app/(screens)/detail/[id].tsx
@@ -102,7 +102,7 @@ export default function DetailScreen() {
 
   return (
     <CustomSafeAreaView>
-      <DetailHeaderBar courseId={Number(id)} />
+      <DetailHeaderBar courseId={Number(id)} courseUserId={data.user_id} />
       <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
         <VStack className="flex-1 px-4">
           <Image

--- a/apps/dog-walk/components/ProfileView.tsx
+++ b/apps/dog-walk/components/ProfileView.tsx
@@ -3,8 +3,10 @@ import { useAtomValue } from "jotai/react";
 import { Dog, PlusCircle } from "lucide-react-native";
 import { useCallback } from "react";
 import { ScrollView, View } from "react-native";
+import { useDeleteDog } from "@/api/reactQuery/dogs/useDeleteDog";
 import { useFindDogs } from "@/api/reactQuery/dogs/useFindDogs";
 import { userAtom } from "@/atoms/userAtom";
+import { getGlobalHandleToast } from "./CustomToast";
 import DogInfoCard from "./card/DogInfoCard";
 import ProfileMenuItem from "./ProfileMenuItem";
 import SectionTitle from "./SectionTitle";
@@ -20,6 +22,17 @@ export default function ProfileView() {
   const userInfo = useAtomValue(userAtom);
 
   const { data: dogsData, refetch: refetchDogsData } = useFindDogs(userInfo.id);
+  const { mutateAsync: deleteDog } = useDeleteDog();
+
+  const handleDeleteDog = async (dogId: number) => {
+    try {
+      await deleteDog(dogId);
+      await refetchDogsData();
+      getGlobalHandleToast("반려견이 삭제되었습니다.");
+    } catch {
+      getGlobalHandleToast("삭제에 실패했습니다.");
+    }
+  };
 
   useFocusEffect(
     useCallback(() => {
@@ -94,9 +107,11 @@ export default function ProfileView() {
                 birthdate={data.birthdate}
                 breed={data.breed}
                 gender={data.gender}
+                id={data.id}
                 imageUrl={data.image_url}
                 key={data.id}
                 name={data.name}
+                onDelete={handleDeleteDog}
               />
             ))}
           </VStack>

--- a/apps/dog-walk/components/actionsheet/OptionsActionsheet.tsx
+++ b/apps/dog-walk/components/actionsheet/OptionsActionsheet.tsx
@@ -1,6 +1,7 @@
 import type { CourseActionType } from "@/types/option";
 
 import { Trash2 } from "lucide-react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import {
   Actionsheet,
   ActionsheetBackdrop,
@@ -25,6 +26,8 @@ export default function OptionsActionsheet({
   setShowActionsheet,
   onPressOption,
 }: OptionsActionsheetProps) {
+  const insets = useSafeAreaInsets();
+
   const handleClose = () => {
     setShowActionsheet(false);
   };
@@ -32,7 +35,7 @@ export default function OptionsActionsheet({
   return (
     <Actionsheet isOpen={showActionsheet} onClose={handleClose}>
       <ActionsheetBackdrop />
-      <ActionsheetContent>
+      <ActionsheetContent style={{ paddingBottom: insets.bottom }}>
         <ActionsheetDragIndicatorWrapper className="pb-5">
           <ActionsheetDragIndicator />
         </ActionsheetDragIndicatorWrapper>

--- a/apps/dog-walk/components/card/DogInfoCard.tsx
+++ b/apps/dog-walk/components/card/DogInfoCard.tsx
@@ -1,24 +1,41 @@
-import { Image } from "react-native";
+import { Trash2 } from "lucide-react-native";
+import { Alert, Image } from "react-native";
 import { calculateAge } from "@/utils/date";
+import { Button, ButtonIcon } from "../ui/button";
 import { HStack } from "../ui/hstack";
 import { Text } from "../ui/text";
 import { VStack } from "../ui/vstack";
 
 type TDogInfoCardProp = {
+  id: number;
   imageUrl: string;
   name: string;
   breed: string;
   birthdate: string;
   gender: string;
+  onDelete: (id: number) => void;
 };
 
 export default function DogInfoCard({
+  id,
   imageUrl,
   name,
   breed,
   birthdate,
   gender,
+  onDelete,
 }: TDogInfoCardProp) {
+  const handleDelete = () => {
+    Alert.alert("반려견 삭제", `${name}을(를) 삭제하시겠어요?`, [
+      { text: "취소", style: "cancel" },
+      {
+        text: "삭제",
+        style: "destructive",
+        onPress: () => onDelete(id),
+      },
+    ]);
+  };
+
   return (
     <HStack className="items-center gap-4 rounded-xl border border-slate-200 p-4">
       <Image className="h-14 w-14 rounded-full" src={imageUrl} />
@@ -31,6 +48,9 @@ export default function DogInfoCard({
           </Text>
         </HStack>
       </VStack>
+      <Button onPress={handleDelete} size="sm" variant="link">
+        <ButtonIcon as={Trash2} className="h-5 w-5 text-slate-400" />
+      </Button>
     </HStack>
   );
 }

--- a/apps/dog-walk/components/organisms/DetailHeaderBar.tsx
+++ b/apps/dog-walk/components/organisms/DetailHeaderBar.tsx
@@ -7,6 +7,7 @@ import {
   Share2,
 } from "lucide-react-native";
 import { useEffect, useState } from "react";
+import { useDeleteCourse } from "@/api/reactQuery/course/useDeleteCourse";
 import { useDeleteLikedCourse } from "@/api/reactQuery/like/useDeleteLikedCourse";
 import { useFindLikedCourse } from "@/api/reactQuery/like/useFindLikedCourse";
 import { useInsertLikedCourse } from "@/api/reactQuery/like/useInsertLikedCourse";
@@ -21,9 +22,13 @@ import { Icon } from "../ui/icon";
 
 interface DetailHeaderBarProps {
   courseId: number;
+  courseUserId?: string;
 }
 
-export default function DetailHeaderBar({ courseId }: DetailHeaderBarProps) {
+export default function DetailHeaderBar({
+  courseId,
+  courseUserId,
+}: DetailHeaderBarProps) {
   const userInfo = useAtomValue(userAtom);
 
   const error500Color = useThemeColor({}, "--color-error-500");
@@ -37,6 +42,9 @@ export default function DetailHeaderBar({ courseId }: DetailHeaderBarProps) {
 
   const { mutateAsync: insertLikeCourse } = useInsertLikedCourse();
   const { mutateAsync: deleteLikeCourse } = useDeleteLikedCourse();
+  const { mutateAsync: deleteCourse } = useDeleteCourse();
+
+  const isOwner = !!userInfo.id && userInfo.id === courseUserId;
 
   const [showOptionsActionsheet, setShowOptionsActionsheet] = useState(false);
   const [showBlockCourseActionsheet, setShowBlockCourseActionsheet] =
@@ -46,6 +54,16 @@ export default function DetailHeaderBar({ courseId }: DetailHeaderBarProps) {
   useEffect(() => {
     setIsLikeCourse(!!id);
   }, [id]);
+
+  const handleDelete = async () => {
+    try {
+      await deleteCourse({ courseId, userId: userInfo.id });
+      getGlobalHandleToast("산책 코스가 삭제되었습니다.");
+      router.back();
+    } catch {
+      getGlobalHandleToast("삭제에 실패했습니다.");
+    }
+  };
 
   const handleLike = async () => {
     try {
@@ -112,11 +130,17 @@ export default function DetailHeaderBar({ courseId }: DetailHeaderBarProps) {
       {/* NOTE: MODAL ==> */}
       <OptionsActionsheet
         onPressOption={() => {
-          setShowOptionsActionsheet(false);
-          setShowBlockCourseActionsheet(true);
+          if (isOwner) {
+            setShowOptionsActionsheet(false);
+            handleDelete();
+          } else {
+            setShowOptionsActionsheet(false);
+            setShowBlockCourseActionsheet(true);
+          }
         }}
         setShowActionsheet={setShowOptionsActionsheet}
         showActionsheet={showOptionsActionsheet}
+        type={isOwner ? "DELETE" : "BLOCK"}
       />
       <BlockCourseActionsheet
         courseId={courseId}


### PR DESCRIPTION
## 설명 (Description)

- 반려견 삭제 기능과 산책 코스 상세 화면에서 본인이 등록한 산책 코스 삭제 기능을 추가했습니다.


## 스크린샷/동영상 (Screenshots/Videos)

| 화면 | 설명 |
|--------|------|
|<img src="https://github.com/user-attachments/assets/454daca0-4115-4162-8ce4-567b24801077" width="200px"  />| 산책 코스 상세 화면 - 본인이 작성한 데이터인 경우 삭제하기 표시 |
|<img src="https://github.com/user-attachments/assets/49b994db-a60e-4627-8e1b-e97f1527f96c" width="200px"  />| 반려견 삭제 버튼 추가 |


## 변경 내용 (Changes Made)

- 반려견 삭제
- [x] useDeleteDog - 반려견 소프트 딜리트 훅 추가, 삭제 성공 시 목록 쿼리 자동 무효화
- [x] useFindDogs - deleted_at IS NULL 필터 누락 수정
- [x] DogInfoCard - 삭제 버튼 추가 및 Alert 확인 처리
- [x] ProfileView - 삭제 기능 연결, 삭제 후 즉시 목록 갱신

- 산책 코스 삭제
- [x] DetailHeaderBar - `courseUserId` prop 추가, 본인 코스 여부에 따라 삭제/신고 분기
- [x] detail/[id].tsx - `user_id`를 DetailHeaderBar로 전달
- [x] OptionsActionsheet - 안드로이드 하단 내비게이션 가림 현상 수정 (safe area 패딩 추가)


## 테스트 방법 (How to Test)

- 반려견 삭제
1. 프로필 화면에서 등록된 반려견 카드의 삭제 아이콘 클릭
2. Alert 확인 후 목록에서 즉시 제거되는지 확인

- 산책 코스 삭제
1. 본인이 등록한 코스 상세 진입 → `⋮` 버튼 클릭 시 "삭제하기" 표시 확인
2. 삭제 후 이전 화면으로 이동하는지 확인
3. 타인이 등록한 코스 상세 진입 → `⋮` 버튼 클릭 시 "이 산책 코스 보지 않기" 표시 확인


## 체크리스트 (Checklist)

- [x] Android에서 테스트 완료