### PR TITLE
feat(dog-walk): 산책 코스 수정 기능 추가 및 키보드 대응

### DIFF
--- a/apps/dog-walk/api/reactQuery/course/useUpdateCourse.ts
+++ b/apps/dog-walk/api/reactQuery/course/useUpdateCourse.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { supabase } from "@/api/supabaseClient";
+import { queryKeys } from "../queryKeys";
+
+interface UpdateCourseParams {
+  courseId: number;
+  userId: string;
+  visitedDate: Date;
+  imageUrl: string;
+  recommendReason: string;
+}
+
+const updateCourse = async ({
+  courseId,
+  userId,
+  visitedDate,
+  imageUrl,
+  recommendReason,
+}: UpdateCourseParams) => {
+  const { error } = await supabase
+    .from("walking_courses")
+    .update({
+      visited_date: visitedDate,
+      image_url: imageUrl,
+      recommend_reason: recommendReason,
+    })
+    .eq("id", courseId)
+    .eq("user_id", userId);
+
+  if (error) throw error;
+
+  return { courseId };
+};
+
+export const useUpdateCourse = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateCourse,
+    onSuccess: ({ courseId }) => {
+      queryClient.invalidateQueries({
+        queryKey: [queryKeys.course.findCourse, courseId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [queryKeys.course.findMyCoursesInfinite],
+      });
+    },
+  });
+};

--- a/apps/dog-walk/app/(screens)/course/edit.tsx
+++ b/apps/dog-walk/app/(screens)/course/edit.tsx
@@ -1,0 +1,177 @@
+import type { ImagePickerAsset } from "expo-image-picker";
+
+import { decode } from "base64-arraybuffer";
+import * as ImagePicker from "expo-image-picker";
+import { router, useLocalSearchParams } from "expo-router";
+import { useAtomValue } from "jotai";
+import { Camera } from "lucide-react-native";
+import { useEffect, useState } from "react";
+import {
+  Image,
+  Platform,
+  ScrollView,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { useFindCourse } from "@/api/reactQuery/course/useFindCourse";
+import { useUpdateCourse } from "@/api/reactQuery/course/useUpdateCourse";
+import { supabase } from "@/api/supabaseClient";
+import { userAtom } from "@/atoms/userAtom";
+import CustomSafeAreaView from "@/components/CustomSafeAreaView";
+import { getGlobalHandleToast } from "@/components/CustomToast";
+import DatePickerModal from "@/components/DatePickerModal";
+import HeaderBar from "@/components/HeaderBar";
+import DatePicker from "@/components/molecules/DatePicker";
+import SectionTitle from "@/components/SectionTitle";
+import { Button, ButtonText } from "@/components/ui/button";
+import { Text } from "@/components/ui/text";
+import { Textarea, TextareaInput } from "@/components/ui/textarea";
+import { useKeyboardHeight } from "@/hooks/useKeyboardHeight";
+
+export default function CourseEditScreen() {
+  const { id } = useLocalSearchParams();
+  const courseId = Number(id);
+  const keyboardHeight = useKeyboardHeight();
+
+  const userInfo = useAtomValue(userAtom);
+  const { data: courseData } = useFindCourse(courseId, userInfo.id);
+  const { mutateAsync: updateCourse } = useUpdateCourse();
+
+  const [date, setDate] = useState(new Date());
+  const [description, setDescription] = useState("");
+  const [image, setImage] = useState<ImagePickerAsset[]>([]);
+  const [existingImageUrl, setExistingImageUrl] = useState("");
+  const [showPicker, setShowPicker] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // NOTE: 기존 코스 데이터 초기값 설정
+  useEffect(() => {
+    if (!courseData) return;
+    setDate(new Date(courseData.visited_date));
+    setDescription(courseData.recommend_reason ?? "");
+    setExistingImageUrl(courseData.image_url ?? "");
+  }, [courseData]);
+
+  const currentImageUri = image[0]?.uri ?? existingImageUrl;
+  const isUpdateEnabled = description.trim().length > 0 && !!currentImageUri;
+
+  const pickImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: true,
+      aspect: [1, 1],
+      quality: 1,
+      base64: true,
+    });
+
+    if (result && !result.canceled && result.assets[0]) {
+      setImage([result.assets[0]]);
+    }
+  };
+
+  const uploadImage = async (asset: ImagePickerAsset): Promise<string> => {
+    if (!asset.base64) throw new Error("이미지를 처리할 수 없습니다.");
+
+    const fileExt = asset.uri.split(".").pop();
+    const filePath = `private/${Date.now()}.${fileExt}`;
+    const fileData = decode(asset.base64);
+
+    const { error } = await supabase.storage
+      .from("dog-walk-images")
+      .upload(filePath, fileData, {
+        contentType: asset.mimeType,
+        upsert: true,
+      });
+
+    if (error) throw error;
+
+    const { data } = supabase.storage
+      .from("dog-walk-images")
+      .getPublicUrl(filePath);
+
+    return data.publicUrl;
+  };
+
+  const onPressUpdate = async () => {
+    setIsSubmitting(true);
+    try {
+      let imageUrl = existingImageUrl;
+
+      // NOTE: 새 이미지를 선택한 경우에만 업로드
+      if (image[0]) {
+        imageUrl = await uploadImage(image[0]);
+      }
+
+      await updateCourse({
+        courseId,
+        userId: userInfo.id,
+        visitedDate: date,
+        imageUrl,
+        recommendReason: description,
+      });
+
+      getGlobalHandleToast("산책 코스가 수정되었습니다.");
+      router.back();
+    } catch {
+      getGlobalHandleToast("수정에 실패했습니다.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <CustomSafeAreaView>
+      <HeaderBar isShowBackButton={true} title={"산책 코스 수정"} />
+      <ScrollView className="flex-1 px-4" showsVerticalScrollIndicator={false}>
+        <SectionTitle title={"다녀온 날짜"}>
+          <DatePicker date={date} setDate={setDate} />
+        </SectionTitle>
+
+        <SectionTitle title={"산책 코스 대표 사진"}>
+          <TouchableOpacity
+            className="flex aspect-[1/1] items-center justify-center rounded-xl bg-slate-50"
+            onPress={pickImage}
+          >
+            {currentImageUri ? (
+              <Image className="h-72 w-72 rounded-xl" src={currentImageUri} />
+            ) : (
+              <View className="flex h-full w-full flex-col items-center justify-center gap-2">
+                <Camera className="h-6 w-6" color={"#6DBE6E"} />
+                <Text className="text-slate-600">사진 추가</Text>
+              </View>
+            )}
+          </TouchableOpacity>
+        </SectionTitle>
+
+        <SectionTitle title={"추천 이유"}>
+          <Textarea>
+            <TextareaInput
+              className="align-top"
+              onChangeText={setDescription}
+              placeholder="산책 코스를 추천하는 이유에 대해 작성해주세요."
+              value={description}
+            />
+          </Textarea>
+        </SectionTitle>
+      </ScrollView>
+      <View className="p-3" style={{ marginBottom: keyboardHeight }}>
+        <Button
+          className="rounded-xl"
+          isDisabled={!isUpdateEnabled || isSubmitting}
+          onPress={onPressUpdate}
+          size={"xl"}
+        >
+          <ButtonText>수정하기</ButtonText>
+        </Button>
+      </View>
+      {/* NOTE: MODAL ==> */}
+      <DatePickerModal
+        date={date}
+        setDate={setDate}
+        setShowModal={setShowPicker}
+        showModal={showPicker && Platform.OS === "ios"}
+      />
+      {/* NOTE: <== MODAL */}
+    </CustomSafeAreaView>
+  );
+}

--- a/apps/dog-walk/app/(tabs)/add.tsx
+++ b/apps/dog-walk/app/(tabs)/add.tsx
@@ -22,11 +22,13 @@ import SectionTitle from "@/components/SectionTitle";
 import { Button, ButtonText } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import { Textarea, TextareaInput } from "@/components/ui/textarea";
+import { useKeyboardHeight } from "@/hooks/useKeyboardHeight";
 import { useRegisterWalkingCourse } from "@/hooks/useRegisterWalkingCourse";
 
 export default function AddScreen() {
   const userInfo = useAtomValue(userAtom);
   const isLoggedIn = Boolean(userInfo.accessToken);
+  const keyboardHeight = useKeyboardHeight();
 
   const [startPoint, setStartPoint] = useAtom(startPointAtom);
   const [endPoint, setEndPoint] = useAtom(endPointAtom);
@@ -200,7 +202,10 @@ export default function AddScreen() {
           </Textarea>
         </SectionTitle>
       </ScrollView>
-      <View className="p-3" style={{ paddingBottom: TAB_BAR_HEIGHT }}>
+      <View
+        className="p-3"
+        style={{ paddingBottom: TAB_BAR_HEIGHT, marginBottom: keyboardHeight }}
+      >
         <Button
           className="rounded-xl"
           isDisabled={!isRegistrationEnabled}

--- a/apps/dog-walk/components/actionsheet/OptionsActionsheet.tsx
+++ b/apps/dog-walk/components/actionsheet/OptionsActionsheet.tsx
@@ -1,6 +1,6 @@
 import type { CourseActionType } from "@/types/option";
 
-import { Trash2 } from "lucide-react-native";
+import { Pencil, Trash2 } from "lucide-react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import {
   Actionsheet,
@@ -18,6 +18,7 @@ interface OptionsActionsheetProps {
   showActionsheet: boolean;
   setShowActionsheet: React.Dispatch<React.SetStateAction<boolean>>;
   onPressOption: () => void;
+  onPressEdit?: () => void;
 }
 
 export default function OptionsActionsheet({
@@ -25,6 +26,7 @@ export default function OptionsActionsheet({
   showActionsheet,
   setShowActionsheet,
   onPressOption,
+  onPressEdit,
 }: OptionsActionsheetProps) {
   const insets = useSafeAreaInsets();
 
@@ -39,13 +41,14 @@ export default function OptionsActionsheet({
         <ActionsheetDragIndicatorWrapper className="pb-5">
           <ActionsheetDragIndicator />
         </ActionsheetDragIndicatorWrapper>
-        {type === "BLOCK" ? (
+        {type === "BLOCK" && (
           <ActionsheetItem onPress={onPressOption}>
             <ActionsheetItemText className="font-medium" size="md">
               이 산책 코스 보지 않기
             </ActionsheetItemText>
           </ActionsheetItem>
-        ) : (
+        )}
+        {type === "DELETE" && (
           <ActionsheetItem onPress={onPressOption}>
             <Icon as={Trash2} className="h-4 w-4 text-error-500" />
             <ActionsheetItemText
@@ -55,6 +58,25 @@ export default function OptionsActionsheet({
               삭제하기
             </ActionsheetItemText>
           </ActionsheetItem>
+        )}
+        {type === "OWNER" && (
+          <>
+            <ActionsheetItem onPress={onPressEdit}>
+              <Icon as={Pencil} className="h-4 w-4 text-slate-700" />
+              <ActionsheetItemText className="font-medium" size="md">
+                수정하기
+              </ActionsheetItemText>
+            </ActionsheetItem>
+            <ActionsheetItem onPress={onPressOption}>
+              <Icon as={Trash2} className="h-4 w-4 text-error-500" />
+              <ActionsheetItemText
+                className="font-medium text-error-500"
+                size="md"
+              >
+                삭제하기
+              </ActionsheetItemText>
+            </ActionsheetItem>
+          </>
         )}
       </ActionsheetContent>
     </Actionsheet>

--- a/apps/dog-walk/components/organisms/DetailHeaderBar.tsx
+++ b/apps/dog-walk/components/organisms/DetailHeaderBar.tsx
@@ -65,6 +65,14 @@ export default function DetailHeaderBar({
     }
   };
 
+  const handleEdit = () => {
+    setShowOptionsActionsheet(false);
+    router.push({
+      pathname: "/(screens)/course/edit" as never,
+      params: { id: courseId },
+    });
+  };
+
   const handleLike = async () => {
     try {
       if (!isLikeCourse) {
@@ -129,6 +137,7 @@ export default function DetailHeaderBar({
       </HStack>
       {/* NOTE: MODAL ==> */}
       <OptionsActionsheet
+        onPressEdit={handleEdit}
         onPressOption={() => {
           if (isOwner) {
             setShowOptionsActionsheet(false);
@@ -140,7 +149,7 @@ export default function DetailHeaderBar({
         }}
         setShowActionsheet={setShowOptionsActionsheet}
         showActionsheet={showOptionsActionsheet}
-        type={isOwner ? "DELETE" : "BLOCK"}
+        type={isOwner ? "OWNER" : "BLOCK"}
       />
       <BlockCourseActionsheet
         courseId={courseId}

--- a/apps/dog-walk/hooks/useKeyboardHeight.ts
+++ b/apps/dog-walk/hooks/useKeyboardHeight.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+import { Keyboard } from "react-native";
+
+export function useKeyboardHeight() {
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+
+  useEffect(() => {
+    const showListener = Keyboard.addListener("keyboardDidShow", (e) => {
+      setKeyboardHeight(e.endCoordinates.height);
+    });
+    const hideListener = Keyboard.addListener("keyboardDidHide", () => {
+      setKeyboardHeight(0);
+    });
+
+    return () => {
+      showListener.remove();
+      hideListener.remove();
+    };
+  }, []);
+
+  return keyboardHeight;
+}

--- a/apps/dog-walk/types/option.ts
+++ b/apps/dog-walk/types/option.ts
@@ -1,3 +1,3 @@
 export type Option = { label: string; value: string };
 
-export type CourseActionType = "BLOCK" | "DELETE";
+export type CourseActionType = "BLOCK" | "DELETE" | "OWNER";


### PR DESCRIPTION
## 설명 (Description)

- 본인이 등록한 산책 코스를 수정할 수 있는 기능을 추가했습니다.
- 키보드가 올라왔을 때 입력 필드와 버튼이 가려지는 UX 문제도 함께 수정했습니다.


## 스크린샷/동영상 (Screenshots/Videos)

| 화면 | 설명 |
|--------|------|
|<img src="https://github.com/user-attachments/assets/d865c066-9b0b-4f9a-ae45-7572df6b4466" width="200px"  />|    산책 코스 수정 화면 |
|<img src="https://github.com/user-attachments/assets/aee5c928-dbfc-4a63-af64-9819bd0c2de6" width="200px"  />| 산책 코스 상세 화면 - 버튼 클릭 시 본인 코스면 수정/삭제, 타인 코스면 차단 옵션 표시  |



## 변경 내용 (Changes Made)

- [x] `useUpdateCourse` - 산책 코스 수정 react query 훅 추가 (날짜, 사진, 추천이유)
- [x] `CourseActionType`에 `OWNER` 타입 추가
- [x] `OptionsActionsheet` - OWNER 타입 시 수정하기/삭제하기 두 옵션 표시
- [x] `app/(screens)/course/edit.tsx` - 코스 수정 화면 추가 (기존 데이터 초기값 자동 설정)
- [x] `DetailHeaderBar` - 본인 코스 여부에 따라 수정 화면으로 이동 연결
- [x] `useKeyboardHeight` 훅 추가 - 키보드 표시 여부에 따라 높이 반환
- [x] `add.tsx`, `edit.tsx` - 키보드가 올라왔을 때 스크롤 영역 및 하단 버튼 위치 동적 조정


## 테스트 방법 (How to Test)

### 산책 코스 수정
1. 본인이 등록한 코스 상세 화면 진입
2. 우측 상단 `⋮` 버튼 클릭 → "수정하기" / "삭제하기" 표시 확인
3. "수정하기" 클릭 → 기존 날짜, 사진, 추천 이유가 초기값으로 채워진 수정 화면 확인
4. 내용 수정 후 "수정하기" 버튼 클릭 → 상세 화면에 수정 내용 반영 확인
5. 타인 코스 상세 진입 → `⋮` 클릭 시 "이 산책 코스 보지 않기"만 표시 확인

### 키보드 대응
1. 코스 등록/수정 화면에서 추천 이유 텍스트 입력란 클릭
2. 키보드가 올라왔을 때 입력란이 가려지지 않고 스크롤 가능한지 확인
3. 하단 버튼이 키보드 위로 올라오는지 확인


## 체크리스트 (Checklist)

- [x] Android에서 테스트 완료