### PR TITLE
chore: remove hardcoded bun path in Claude hook commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/Users/gracefullight/.bun/bin/bun\" \"$CLAUDE_PROJECT_DIR/.claude/hooks/keyword-detector.ts\"",
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/keyword-detector.ts\"",
             "timeout": 5
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/Users/gracefullight/.bun/bin/bun\" \"$CLAUDE_PROJECT_DIR/.claude/hooks/test-filter.ts\"",
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/test-filter.ts\"",
             "timeout": 5
           }
         ],
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"/Users/gracefullight/.bun/bin/bun\" \"$CLAUDE_PROJECT_DIR/.claude/hooks/persistent-mode.ts\"",
+            "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/persistent-mode.ts\"",
             "timeout": 5
           }
         ]
@@ -37,7 +37,7 @@
   },
   "statusLine": {
     "type": "command",
-    "command": "\"/Users/gracefullight/.bun/bin/bun\" \"$CLAUDE_PROJECT_DIR/.claude/hooks/hud.ts\""
+    "command": "bun \"$CLAUDE_PROJECT_DIR/.claude/hooks/hud.ts\""
   },
   "permissions": {
     "allow": [


### PR DESCRIPTION
## 문제

`.claude/settings.json`의 훅 명령어에 특정 개발자의 절대 경로가 하드코딩되어 있었습니다.

```json
"/Users/gracefullight/.bun/bin/bun" "$CLAUDE_PROJECT_DIR/.claude/hooks/..."
```

이로 인해 해당 사용자 외 모든 협업자의 로컬 환경에서 Claude Code 훅 실행 시 다음과 같은 오류가 발생했습니다.

```
Stop hook error: Failed with non-blocking status code:
/bin/sh: /Users/gracefullight/.bun/bin/bun: No such file or directory
```

## 원인 분석

`.claude/settings.json`은 git에 커밋된 공유 파일이지만, 내부 런타임 경로가 특정 머신의 홈 디렉토리에 종속되어 있었습니다. 각 개발자의 bun 설치 위치는 다를 수 있습니다.

- mise 관리: `~/.local/share/mise/installs/bun/x.x.x/bin/bun`  
- bun 직접 설치: `~/.bun/bin/bun`

## 수정 내용

절대 경로를 제거하고 런타임 이름만 사용하도록 변경했습니다.

```json
// 이전
"/Users/gracefullight/.bun/bin/bun" "$CLAUDE_PROJECT_DIR/.claude/hooks/..."

// 이후
bun "$CLAUDE_PROJECT_DIR/.claude/hooks/..."
```

영향받는 훅 4개:
- `UserPromptSubmit` → `keyword-detector.ts`
- `PreToolUse` (Bash matcher) → `test-filter.ts`
- `Stop` → `persistent-mode.ts`
- `statusLine` → `hud.ts`

## 동작 보장 근거

본 프로젝트는 mise를 통해 런타임을 관리합니다. mise는 shim 디렉토리(`~/.local/share/mise/shims`)를 사용자 PATH에 등록하므로, Claude Code 훅이 사용자 쉘을 통해 실행될 때 `bun` 명령어가 정상적으로 resolve됩니다. bun을 직접 설치한 경우에도 설치 시 `~/.bun/bin`이 PATH에 자동 추가됩니다.

## 검증

```bash
bun "$CLAUDE_PROJECT_DIR/.claude/hooks/persistent-mode.ts"  # 정상 실행 확인
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)